### PR TITLE
[codex] Reorganize docs and add implementation status guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,67 @@
+# Docs Guide
+
+This folder is organized by purpose rather than by a global numbering scheme.
+
+## Start Here
+
+- [Project Instructions](project-instructions.md)
+  Collaboration rules, transparency tenet, persona model, and the main reference list.
+- [Current Implementation Status](current-implementation-status.md)
+  Practical snapshot of what is implemented right now.
+
+## Product And Planning
+
+- [PRD v2.3](prd-v2.3.md)
+  Product requirements, financial model, QA checklist, and release scope.
+- [Build Plan v1.2](build-plan.md)
+  Phase-by-phase delivery plan and dependencies.
+- [Internal API Contract](internal-api-contract.md)
+  Intended API surface and response conventions.
+- [Implementation Backlog](implementation-backlog.md)
+  Proposed updates, amendments, and follow-up work identified during development.
+
+## Phase Plans
+
+- [Phase 1 Foundation Spec](plans/phase-1-foundation-spec.md)
+- [Phase 2 Implementation Plan](plans/phase-2-implementation-plan.md)
+- [Phase 3 Implementation Plan](plans/phase-3-implementation-plan.md)
+
+Use these when planning or validating work within a specific phase.
+
+## Standards
+
+- [Security Standard](standards/security.md)
+- [Accessibility Standard](standards/accessibility.md)
+- [Testing Standard](standards/testing.md)
+
+These are implementation rules, not optional guidance.
+
+## ADRs
+
+- [ADR Index](adrs/adr-000-index.md)
+
+ADRs keep their numbering because they are stable architectural records. Outside the ADRs, descriptive filenames are preferred over a repository-wide numeric scheme.
+
+## Naming Notes
+
+- ADRs remain numbered: `ADR-001`, `ADR-002`, and so on.
+- Phase-specific execution docs live in `docs/plans/`.
+- Standards live in `docs/standards/`.
+- Top-level docs are reserved for the most important cross-cutting references.
+
+## Maintenance Notes
+
+- Prefer updating links immediately when files move or are renamed.
+- Use this file as the main entry point for future documentation cleanup.
+- Avoid duplicating the same guidance across multiple docs when one canonical source can be linked instead.
+
+## Source Of Truth
+
+When multiple docs touch the same topic, use this order of precedence:
+
+1. ADRs for architectural decisions that explicitly change or constrain prior assumptions.
+2. PRD for product behavior, financial rules, and release scope.
+3. Build plan for sequencing, dependencies, and phase exit criteria.
+4. Phase plans/specs for execution detail within a specific phase.
+5. Current implementation status for repo reality today.
+6. Implementation backlog for follow-up ideas that are not yet canonical.

--- a/docs/adrs/adr-000-index.md
+++ b/docs/adrs/adr-000-index.md
@@ -34,5 +34,7 @@ ADR-006 (Bulk migration removal) — no chain dependency; supersedes PRD §11.6 
 
 ## Related documents
 
-- [PRD v2.3](../shopify_donation_manager_prd_v2-3.md)
+- [Docs guide](../README.md)
+- [PRD v2.3](../prd-v2.3.md)
+- [Build Plan v1.2](../build-plan.md)
 - Feasibility checklist (inline in session notes — to be extracted)

--- a/docs/build-plan.md
+++ b/docs/build-plan.md
@@ -1,11 +1,15 @@
 # Phased Build Plan — Shopify Donation Manager
 
+Use this document for sequencing, dependencies, phase boundaries, and exit criteria.
+
+This is the authoritative delivery roadmap. It explains when work should happen and what must be true before the next phase begins.
+
 **Version:** 1.2
 **Date:** March 2026  
 **Developer:** Solo  
 **Phase definition:** Each phase ends when all work in that phase is complete, tested, and verifiable on a development store. No phase begins until the previous phase passes its exit criteria.
 
-**v1.2 — March 2026:** §1.3 — replaced `RecalculationRun` with `DeletionJob` as the fourth Phase 1 schema table. RecalculationRun has no Phase 1 role (removed via BE-1 panel flag). DeletionJob is required in Phase 1 to support the uninstall/reinstall lifecycle. See Phase 1 feature spec v1.1 §3.4.
+**v1.2 — March 2026:** §1.3 — replaced `RecalculationRun` with `DeletionJob` as the fourth Phase 1 schema table. RecalculationRun has no Phase 1 role (removed via BE-1 panel flag). DeletionJob is required in Phase 1 to support the uninstall/reinstall lifecycle. See Phase 1 foundation spec v1.1 §3.4.
 
 
 ---

--- a/docs/current-implementation-status.md
+++ b/docs/current-implementation-status.md
@@ -1,0 +1,137 @@
+# Current Implementation Status
+
+Use this document as the practical snapshot of what is implemented in the repo today.
+
+This file is intentionally lightweight and operational. It should summarize reality, not restate full product requirements or phase specs.
+
+**Project:** Count On Us  
+**Date:** April 2, 2026  
+**Summary:** Phase 1 is complete. Phase 2 is largely implemented and currently being hardened. The team is wrapping up pre-Phase-3 issues before beginning the immutable snapshot, causes, and order accounting work.
+
+---
+
+## Current Position
+
+- **Phase 1:** Complete
+- **Phase 2:** Mostly complete
+- **Current focus:** Phase 2 hardening and pre-Phase-3 cleanup
+- **Phase 3:** Not yet started in substantive backend/data-model terms
+
+---
+
+## Phase 1 Checklist
+
+- [x] Shopify app shell and embedded admin wiring
+- [x] OAuth and session flow
+- [x] Core Phase 1 schema (`Shop`, `WizardState`, `AuditLog`, `DeletionJob`)
+- [x] Post-install handling and reinstall-within-window lifecycle
+- [x] Webhook HMAC verification
+- [x] Job queue bootstrapping
+- [x] Dashboard and Settings shell
+- [x] Tenant guardrails in Prisma
+- [~] Phase 1 testing expectations appear functionally covered, but not all expected automated verification is visible in the repo
+
+---
+
+## Phase 2 Checklist
+
+### Core cost model
+
+- [x] Phase 2 Prisma schema
+- [x] Catalog sync service
+- [x] Install-triggered catalog sync
+- [x] Incremental catalog sync for product updates
+- [x] Material Library CRUD UI
+- [x] Equipment Library CRUD UI
+- [x] Cost Templates list/detail UI
+- [x] Variant list with filtering
+- [x] Bulk template assignment
+- [x] Variant detail configuration page
+- [x] CostEngine implementation
+- [x] Mistake buffer setting
+- [x] Default labor rate groundwork
+- [x] Currency/localization groundwork
+
+### Still being hardened
+
+- [~] Audit logging is present across many flows, but should be spot-checked against all documented required mutations
+- [~] Validation exists in many actions, but is not yet consistently standardized around Zod
+- [~] CostEngine behavior is implemented, but documented unit-test expectations do not appear fully in place
+- [~] Template and variant UX is still being refined as part of Phase 2 wrap-up
+
+### Deferred or intentionally incomplete
+
+- [ ] POD/provider connections
+- [ ] Full inline bulk editor
+- [ ] Formal Vitest setup and documented test scripts
+
+---
+
+## Pre-Phase-3 Cleanup Checklist
+
+- [ ] Finish remaining Phase 2 amendment work on templates and variants
+- [ ] Clean up hardcoded localization defaults and connect formatter inputs to real shop data
+- [ ] Verify shipping-material costing behavior matches the intended rules
+- [ ] Verify default labor rate fallback everywhere costs are resolved
+- [ ] Confirm `lineItemCount` stays correct through all add/remove paths
+- [ ] Replace temporary webhook behavior that should not carry into Phase 3
+- [ ] Add or finish automated tests for CostEngine and critical validation paths
+- [ ] Reconcile docs and code before starting Phase 3 implementation
+
+---
+
+## Phase 3 Checklist
+
+- [ ] Cause schema and metaobject sync
+- [ ] Product cause assignment
+- [ ] Snapshot schema
+- [ ] Snapshot service
+- [ ] Refund/adjustment service
+- [ ] Tax offset cache
+- [ ] Business expenses
+- [ ] Reconciliation job
+- [ ] Order history pages
+- [ ] Real `orders/create`, `orders/updated`, and `refunds/create` processing
+
+---
+
+## Phase 4 Checklist
+
+- [ ] Reporting periods
+- [ ] Cause allocation materialization
+- [ ] Shopify charge sync
+- [ ] Reporting dashboard
+- [ ] Disbursements
+- [ ] Tax true-up
+- [ ] Export flows
+- [ ] Audit log browsing UI
+
+---
+
+## Phase 5 Checklist
+
+- [ ] Storefront widget endpoint
+- [ ] Theme app extension
+- [ ] Cart donation summary
+- [ ] Thank You / Order Status extension
+- [ ] Post-purchase donation email
+- [ ] App Proxy donation receipts page
+- [ ] Full setup wizard
+
+---
+
+## Phase 6 Checklist
+
+- [ ] App Store preparation and submission hardening
+- [ ] Full QA pass against the PRD checklist
+- [ ] Demo store setup
+- [ ] Listing assets and copy
+- [ ] Final pre-submission review
+
+---
+
+## Notes
+
+- This file is a practical implementation snapshot, not the source of product requirements.
+- The PRD, build plan, ADRs, and implementation plans remain authoritative for scope and architecture.
+- Update this file when a phase meaningfully changes state, not for every small commit.

--- a/docs/implementation-backlog.md
+++ b/docs/implementation-backlog.md
@@ -1,4 +1,8 @@
-# Proposed Updates
+# Implementation Backlog
+
+Use this document for post-spec amendments, follow-up improvements, and design or implementation issues discovered during development.
+
+This is not the source of record for shipped scope. Items here become authoritative only when they are folded into the PRD, build plan, ADRs, or a phase implementation plan.
 
 Issues and improvement ideas identified during Phase 2 development and testing. Each item is analysed, given a complexity estimate, and assigned to the most appropriate phase.
 

--- a/docs/internal-api-contract.md
+++ b/docs/internal-api-contract.md
@@ -1,5 +1,9 @@
 # Internal API Contract — Shopify Donation Manager
 
+Use this document as the intended contract for internal and extension-facing endpoints.
+
+It is a design reference, not proof that every endpoint is already implemented. Check the current implementation status and the codebase before assuming an endpoint is live.
+
 **Version:** 1.0  
 **Date:** March 2026  
 **Style:** REST  

--- a/docs/plans/phase-1-foundation-spec.md
+++ b/docs/plans/phase-1-foundation-spec.md
@@ -1,4 +1,8 @@
-# Phase 1 Feature Spec — Foundation
+# Phase 1 Foundation Spec
+
+Use this document as the execution-level spec for Phase 1.
+
+It translates the build plan into concrete implementation detail for the foundation phase. If this document conflicts with the build plan, ADRs, or PRD, treat those higher-level documents as authoritative unless this spec reflects an intentional later clarification.
 
 **App:** Count On Us
 **Version:** 1.1

--- a/docs/plans/phase-2-implementation-plan.md
+++ b/docs/plans/phase-2-implementation-plan.md
@@ -1,5 +1,9 @@
 # Phase 2 Implementation Plan — Count On Us
 
+Use this document as the execution plan for Phase 2.
+
+It turns the build plan and ADR decisions into a concrete implementation sequence for the cost-model work. It should stay implementation-oriented and avoid restating product requirements unless they directly affect execution.
+
 ## Context
 
 Phase 1 is complete and verified. Phase 2 builds the cost model: schema, CatalogSync, material/equipment/template libraries, variant cost configuration, and CostEngine. POD provider connections (2.9) are deferred to a follow-on. Bulk inline cell editing is replaced with multi-select + template assignment for now.

--- a/docs/plans/phase-3-implementation-plan.md
+++ b/docs/plans/phase-3-implementation-plan.md
@@ -1,5 +1,9 @@
 # Phase 3 Implementation Plan — Count On Us
 
+Use this document as the execution plan for Phase 3.
+
+It turns the build plan and ADR decisions into a concrete implementation sequence for causes, snapshots, adjustments, and related financial workflows. It should stay implementation-oriented and avoid duplicating PRD language unless the detail is needed to build safely.
+
 ## Context
 
 Phase 2 is complete and verified. Phase 3 introduces causes, the immutable snapshot system, business expenses, order webhook handlers, and the order history page. This is the most financially critical phase — the correctness of every subsequent report, disbursement, and tax estimate depends on snapshots being created accurately and atomically.
@@ -10,7 +14,7 @@ POD provider connections remain deferred (Phase 2.9). The snapshot system is des
 
 ## Pre-Phase 3 amendments (complete before starting Phase 3 steps)
 
-The following items from `docs/proposed-updates.md` must be completed first. They affect the cost model that SnapshotService will consume:
+The following items from `docs/implementation-backlog.md` must be completed first. They affect the cost model that SnapshotService will consume:
 
 - **PU-1** — Uses-based costing for shipping materials  
 - **PU-2** — Searchable pickers + editable lines in template editor  

--- a/docs/prd-v2.3.md
+++ b/docs/prd-v2.3.md
@@ -2,6 +2,10 @@
 
 Product Requirements Document
 
+This is the primary product-definition document for the app. Use it for scope, financial rules, user-facing behavior, QA expectations, and release intent.
+
+When this document conflicts with an implementation detail elsewhere, treat the PRD as authoritative unless a newer ADR explicitly changes the decision.
+
 Version 2.3  |  Foundation Build
 
 March 2026

--- a/docs/project-instructions.md
+++ b/docs/project-instructions.md
@@ -1,5 +1,11 @@
 # Project Instructions — Shopify Donation Manager
 
+## Purpose
+
+Use this document for project-wide working rules: the transparency tenet, collaboration model, personas, review expectations, and the core document map.
+
+This is the best starting point when deciding how work should be done. Use the PRD, build plan, ADRs, and phase plans for what should be built.
+
 ## Primary tenet
 
 **Transparency is valued over all else.**
@@ -210,14 +216,22 @@ If the answer to any of these is "no" or "not fully," the feature must be rework
 
 All decisions in this project are grounded in the following documents. When a persona raises a concern, they should reference the relevant section where applicable.
 
-- [PRD v2.1](shopify_donation_manager_prd_v2-1.md)
-- [Phased Build Plan v1.0](phased-build-plan.md)
-- [ADR-000 Index](adr-000-index.md)
-- [ADR-001 Immutable snapshot architecture](adr-001-immutable-snapshot-architecture.md)
-- [ADR-002 Dual-track financial model](adr-002-dual-track-financial-model.md)
-- [ADR-003 Cost resolution strategy](adr-003-cost-resolution-strategy.md)
-- [ADR-004 Storefront widget data delivery](adr-004-storefront-widget-data-delivery.md)
-- [ADR-005 Direct Giving Mode](adr-005-direct-giving-mode.md)
+- [Docs guide](README.md)
+- [Current implementation status](current-implementation-status.md)
+- [PRD v2.3](prd-v2.3.md)
+- [Build Plan v1.2](build-plan.md)
+- [Internal API Contract](internal-api-contract.md)
+- [Implementation Backlog](implementation-backlog.md)
+- [Phase 1 Foundation Spec](plans/phase-1-foundation-spec.md)
+- [Phase 2 Implementation Plan](plans/phase-2-implementation-plan.md)
+- [Phase 3 Implementation Plan](plans/phase-3-implementation-plan.md)
+- [ADR-000 Index](adrs/adr-000-index.md)
+- [ADR-001 Immutable snapshot architecture](adrs/adr-001-immutable-snapshot-architecture.md)
+- [ADR-002 Dual-track financial model](adrs/adr-002-dual-track-financial-model.md)
+- [ADR-003 Cost resolution strategy](adrs/adr-003-cost-resolution-strategy.md)
+- [ADR-004 Storefront widget data delivery](adrs/adr-004-storefront-widget-data-delivery.md)
+- [ADR-005 Direct Giving Mode](adrs/adr-005-direct-giving-mode.md)
+- [ADR-006 Bulk migration removal](adrs/adr-006-bulk-migration-removal.md)
 
 ---
 


### PR DESCRIPTION
## Summary

- add a docs landing page and current implementation status guide
- rename major docs for readability and align phase-plan naming
- clarify each document's purpose and update stale internal references

## Details

This PR reorganizes the documentation set so it is easier to navigate and maintain while keeping the content low-risk.

It adds a `docs/README.md` entry point, adds `docs/current-implementation-status.md` to reflect actual repo progress, renames several documents to clearer names, and updates cross-links so the docs point at the files that now exist.

It also adds brief context to key docs so readers can tell which document is canonical for product scope, build sequencing, execution planning, and current implementation reality.

## Validation

- reviewed staged diff for docs-only scope
- no automated tests run because this is a documentation-only change