### PR TITLE
[codex] Strengthen QA test guidance in docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,8 @@ See [docs/standards/testing.md](docs/standards/testing.md) for full details.
 
 Key rules:
 - Pure calculation functions (cost engine, financial helpers) must have unit tests.
+- Bug fixes and behavior corrections should usually add a regression test that would fail if the bug returns.
+- Changes to financial resolution, validation, normalization, or state-merging logic should be assumed to need regression coverage unless there is a clear written reason they do not.
 - Tests live adjacent to their source file: `costEngine.server.test.ts` alongside `costEngine.server.ts`.
 - Do not mock the database in integration tests — use a real test database.
 - Use Vitest as the test runner.
@@ -187,3 +189,11 @@ The pre-commit hook runs in order:
 3. TuringMind code review — blocks on Critical severity findings
 
 Steps 1 and 2 block the commit immediately on failure. Do not use `git commit --no-verify` to bypass them. Fix the root cause.
+
+Before every commit, run a brief QA Engineer persona pass and answer: "What tests should exist if this change breaks?" At minimum, check for:
+- new or changed financial branches that need unit tests
+- bug fixes that should add a regression test
+- validation changes that should add schema coverage
+- workflow or merge/reset behavior that should be covered by a service or integration test
+
+If no new tests are added, record the reason in the commit notes, PR description, or working notes so the omission is explicit rather than accidental.

--- a/docs/project-instructions.md
+++ b/docs/project-instructions.md
@@ -63,6 +63,8 @@ Each persona speaks in a clearly labelled block. Two signal levels are used:
 - Identify edge cases not covered by the current spec or QA checklist
 - Flag when a change to one area is likely to affect another area not currently being considered
 - Propose test cases and acceptance criteria, not just identify gaps
+- Before each commit, identify any missing unit, regression, service, or integration tests that should ship with the change
+- Treat bug fixes and behavior corrections as presumed regression-test candidates unless there is a clear reason they cannot be covered meaningfully
 
 ---
 
@@ -173,6 +175,23 @@ Format:
 ```
 
 If no concern exists, the persona may be omitted from the response entirely — silence means no concerns in that domain.
+
+### Pre-commit QA check-in
+
+Before creating a commit, the **QA Engineer** persona performs a short test review. The goal is to identify missing coverage while the change is still in progress, not after the PR is already open.
+
+Minimum questions:
+- What behavior changed?
+- What existing test would fail if this regressed?
+- If no such test exists, what test should be added?
+
+For code changes, this review should explicitly consider:
+- regression tests for bug fixes
+- unit tests for financial or normalization logic
+- service or integration tests for assignment, reset, merge, and persistence workflows
+- validation tests when input rules change
+
+If the conclusion is that no new test is needed, that decision should be stated explicitly in the commit or PR context.
 
 ### Full panel milestone reviews
 

--- a/docs/standards/testing.md
+++ b/docs/standards/testing.md
@@ -48,6 +48,25 @@ Mandatory test coverage:
 - Template vs. variant override merge logic
 - Edge cases: no config (all zeros), zero prices, null optional fields
 
+### Always test: regressions for fixed bugs and corrected behavior
+
+When a bug is found and fixed, add the smallest durable test that would fail if the bug comes back. Treat this as the default, especially when the bug affects financial outcomes, configuration state, or admin workflows.
+
+High-priority regression targets:
+- financial calculation bugs in cost resolution, rounding, fallback, or normalization
+- template assignment, override, reset, and merge behavior
+- data-shaping bugs where the same record can appear in multiple UI sections
+- state transitions that can leave stale flags, stale badges, or orphaned rows behind
+- validation bugs where malformed or incomplete input was previously accepted
+- locale, currency, and formatting logic that can throw at render time or display incorrect money values
+
+Preferred test level:
+- unit test for pure calculation and normalization logic
+- service test for orchestration and persistence rules
+- integration test for database-backed workflows with meaningful state transitions
+
+If you choose not to add a regression test for a bug fix, document why in the PR description or working notes.
+
 ### Always test: Zod validation schemas
 
 When you add a Zod schema for action input validation, write a test that verifies:
@@ -62,6 +81,8 @@ Services like `catalogSync.server.ts` or `installService.server.ts` contain cond
 ### Do not test: Remix loaders and actions directly
 
 Loaders and actions are integration points — they authenticate, query the DB, and return responses. Testing them in isolation requires mocking too many layers to be meaningful. Test the underlying service functions instead.
+
+If a loader or action bug is fixed, prefer extracting the affected derivation, normalization, or persistence logic into a service/helper that can be tested directly rather than leaving the behavior untested.
 
 ### Do not test: Polaris component rendering
 
@@ -172,6 +193,26 @@ No coverage requirement for:
 - Route files (loaders, actions, components)
 - Database migration scripts
 - Configuration files
+
+---
+
+## Pre-Commit QA Test Review
+
+Before every commit, perform a short QA review focused on missing tests. Ask:
+- What behavior changed?
+- What would break if this change regressed next week?
+- Is that behavior already covered by a test?
+- If not, should the coverage be unit, service, integration, or regression-focused?
+
+This review is especially important when a change touches:
+- financial logic
+- validation
+- data normalization or fallback behavior
+- assignment/reset/merge workflows
+- currency or locale formatting
+- bug fixes prompted by QA, review, or production-like testing
+
+The expected default is to add or update tests in the same branch as the code change. When no test is added, the reason should be explicit.
 
 Run coverage to identify gaps, not to enforce a threshold:
 ```sh


### PR DESCRIPTION
## Summary

- strengthen the testing standard around regression coverage for bug fixes and behavior corrections
- add a pre-commit QA test review expectation to the project instructions
- align `CLAUDE.md` so the AI workflow explicitly asks what tests should exist before each commit lands

## Why

We agreed that regression tests should be part of the default workflow, especially for financial logic, validation, normalization, and merge/reset behavior. This PR updates the project guidance so missing test coverage gets surfaced before commit time instead of after review.

## Impact

- makes regression-test expectations explicit in the repo standards
- gives the QA Engineer persona a concrete pre-commit responsibility
- creates a clear paper trail when a change intentionally ships without new tests

## Validation

- docs-only change
- no automated tests run
