### PR TITLE
Complete Shopify React removal migration

### DIFF
--- a/app/components/AppSaveBar.tsx
+++ b/app/components/AppSaveBar.tsx
@@ -1,4 +1,4 @@
-import { SaveBar } from "@shopify/app-bridge-react";
+import { useEffect, useId } from "react";
 
 type AppSaveBarProps = {
   open: boolean;
@@ -19,14 +19,32 @@ export function AppSaveBar({
   saveDisabled = false,
   loading = false,
 }: AppSaveBarProps) {
+  const id = useId().replace(/:/g, "");
+
+  useEffect(() => {
+    const api = (globalThis as any).shopify?.saveBar;
+    if (!api) return;
+
+    const action = open ? api.show?.(id) : api.hide?.(id);
+    void action;
+
+    return () => {
+      void api.hide?.(id);
+    };
+  }, [id, open]);
+
   return (
-    <SaveBar open={open} discardConfirmation>
-      <button type="button" variant="primary" disabled={saveDisabled} loading={loading} onClick={onSave}>
-        {saveLabel}
+    <ui-save-bar id={id}>
+      <button
+        type="button"
+        disabled={saveDisabled || loading}
+        onClick={onSave}
+      >
+        {loading ? "Saving..." : saveLabel}
       </button>
       <button type="button" disabled={loading} onClick={onDiscard}>
         {discardLabel}
       </button>
-    </SaveBar>
+    </ui-save-bar>
   );
 }

--- a/app/components/polaris-shim.tsx
+++ b/app/components/polaris-shim.tsx
@@ -1,0 +1,539 @@
+import { useEffect, useId, useRef, useState, type CSSProperties, type ReactNode } from "react";
+
+type Tone = "critical" | "success" | "warning" | "subdued" | "enabled" | "info" | "attention" | "caution";
+
+function spacingValue(token?: string) {
+  if (!token) return undefined;
+  const numeric = Number(token);
+  if (Number.isNaN(numeric)) return token;
+  return `${numeric / 400}rem`;
+}
+
+function toneColor(tone?: Tone) {
+  switch (tone) {
+    case "critical":
+      return "#8e1f1f";
+    case "success":
+      return "#0f6b3c";
+    case "warning":
+    case "caution":
+      return "#8a5a00";
+    case "subdued":
+      return "var(--p-color-text-subdued, #6d7175)";
+    case "info":
+      return "#005bd3";
+    case "attention":
+      return "#8a5a00";
+    case "enabled":
+      return "#4a4f55";
+    default:
+      return "inherit";
+  }
+}
+
+export function TitleBar({ title }: { title: string }) {
+  return <ui-title-bar title={title} />;
+}
+
+export function Page({
+  children,
+  title,
+  backAction,
+  titleMetadata,
+}: {
+  children: ReactNode;
+  title?: string;
+  backAction?: { content: string; onAction: () => void };
+  titleMetadata?: ReactNode;
+}) {
+  return (
+    <>
+      {title && !backAction ? <ui-title-bar title={title} /> : null}
+      <s-page>
+        {(title || backAction) && (
+          <div style={{ display: "flex", alignItems: "center", gap: "0.75rem", marginBottom: "1.5rem" }}>
+            {backAction ? (
+              <button
+                type="button"
+                onClick={backAction.onAction}
+                style={{
+                  border: "none",
+                  background: "transparent",
+                  color: "var(--p-color-text-subdued, #6d7175)",
+                  cursor: "pointer",
+                  padding: 0,
+                }}
+              >
+                {backAction.content}
+              </button>
+            ) : null}
+            {title ? <h1 style={{ margin: 0, fontSize: "1.5rem" }}>{title}</h1> : null}
+            {titleMetadata ? <div>{titleMetadata}</div> : null}
+          </div>
+        )}
+        {children}
+      </s-page>
+    </>
+  );
+}
+
+export function Card({ children, padding = "400" }: { children: ReactNode; padding?: string }) {
+  return (
+    <div
+      style={{
+        background: "var(--p-color-bg-surface, #fff)",
+        border: "1px solid var(--p-color-border, #d2d5d8)",
+        borderRadius: "1rem",
+        padding: spacingValue(padding) ?? "1rem",
+        boxShadow: "0 1px 2px rgba(0,0,0,0.04)",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function BlockStack({ children, gap = "400" }: { children: ReactNode; gap?: string }) {
+  return <div style={{ display: "grid", gap: spacingValue(gap) ?? "1rem" }}>{children}</div>;
+}
+
+export function InlineStack({
+  children,
+  gap = "400",
+  align,
+  blockAlign,
+  wrap = true,
+}: {
+  children: ReactNode;
+  gap?: string;
+  align?: "space-between" | "start" | "center" | "end";
+  blockAlign?: "start" | "center" | "end";
+  wrap?: boolean;
+}) {
+  const justifyContent =
+    align === "space-between"
+      ? "space-between"
+      : align === "center"
+        ? "center"
+        : align === "end"
+          ? "flex-end"
+          : "flex-start";
+
+  const alignItems = blockAlign === "center" ? "center" : blockAlign === "end" ? "flex-end" : "flex-start";
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: spacingValue(gap) ?? "1rem",
+        justifyContent,
+        alignItems,
+        flexWrap: wrap ? "wrap" : "nowrap",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function Divider() {
+  return <hr style={{ border: 0, borderTop: "1px solid var(--p-color-border, #d2d5d8)", margin: 0 }} />;
+}
+
+export function Text({
+  children,
+  as = "p",
+  tone,
+  fontWeight,
+}: {
+  children: ReactNode;
+  as?: keyof JSX.IntrinsicElements;
+  variant?: string;
+  tone?: Tone;
+  fontWeight?: "semibold" | "bold";
+}) {
+  const Component = as as keyof JSX.IntrinsicElements;
+  const style: CSSProperties = {
+    margin: 0,
+    color: toneColor(tone),
+    fontWeight: fontWeight === "bold" ? 700 : fontWeight === "semibold" ? 600 : undefined,
+  };
+  return <Component style={style}>{children}</Component>;
+}
+
+export function Badge({ children, tone }: { children: ReactNode; tone?: Tone }) {
+  const badgeTone = tone === "attention" ? "warning" : tone === "enabled" ? "enabled" : tone;
+  return <s-badge tone={badgeTone as any}>{children}</s-badge>;
+}
+
+export function Banner({
+  children,
+  tone,
+  heading,
+}: {
+  children: ReactNode;
+  tone?: "critical" | "success" | "warning";
+  heading?: string;
+}) {
+  return (
+    <s-banner tone={tone} heading={heading}>
+      <div style={{ display: "grid", gap: "0.5rem" }}>{children}</div>
+    </s-banner>
+  );
+}
+
+export function Button({
+  children,
+  onClick,
+  variant,
+  tone,
+  submit,
+  disabled,
+  loading,
+}: {
+  children: ReactNode;
+  onClick?: () => void;
+  variant?: "plain" | "primary";
+  tone?: Tone;
+  submit?: boolean;
+  disabled?: boolean;
+  loading?: boolean;
+}) {
+  const resolvedVariant = variant === "plain" ? "secondary" : "primary";
+  return (
+    <s-button
+      type={submit ? "submit" : "button"}
+      variant={resolvedVariant as any}
+      tone={tone === "attention" ? "warning" : (tone as any)}
+      disabled={disabled || loading}
+      onClick={onClick}
+    >
+      {loading ? "Working..." : children}
+    </s-button>
+  );
+}
+
+export function TextField({
+  label,
+  value,
+  onChange,
+  autoComplete,
+  disabled,
+  type,
+  min,
+  max,
+  step,
+  helpText,
+  placeholder,
+  multiline,
+  name,
+}: {
+  label: string;
+  value: string;
+  onChange?: (value: string) => void;
+  autoComplete?: string;
+  disabled?: boolean;
+  type?: string;
+  min?: number;
+  max?: number;
+  step?: number;
+  helpText?: string;
+  placeholder?: string;
+  multiline?: number | boolean;
+  name?: string;
+}) {
+  const id = useId();
+
+  if (multiline) {
+    return (
+      <div style={{ display: "grid", gap: "0.35rem" }}>
+        <label htmlFor={id}>{label}</label>
+        <textarea
+          id={id}
+          name={name}
+          rows={typeof multiline === "number" ? multiline : 3}
+          value={value}
+          onChange={(event) => onChange?.(event.currentTarget.value)}
+          autoComplete={autoComplete}
+          disabled={disabled}
+          placeholder={placeholder}
+          style={{
+            width: "100%",
+            padding: "0.75rem",
+            borderRadius: "0.75rem",
+            border: "1px solid var(--p-color-border, #d2d5d8)",
+            font: "inherit",
+          }}
+        />
+        {helpText ? <Text as="p" tone="subdued">{helpText}</Text> : null}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "grid", gap: "0.35rem" }}>
+      <label htmlFor={id}>{label}</label>
+      <input
+        id={id}
+        name={name}
+        type={type ?? "text"}
+        value={value}
+        onChange={(event) => onChange?.(event.currentTarget.value)}
+        autoComplete={autoComplete}
+        disabled={disabled}
+        min={min}
+        max={max}
+        step={step}
+        placeholder={placeholder}
+        style={{
+          width: "100%",
+          padding: "0.75rem",
+          borderRadius: "0.75rem",
+          border: "1px solid var(--p-color-border, #d2d5d8)",
+          font: "inherit",
+        }}
+      />
+      {helpText ? <Text as="p" tone="subdued">{helpText}</Text> : null}
+    </div>
+  );
+}
+
+export function Select({
+  label,
+  options,
+  value,
+  onChange,
+  labelHidden,
+}: {
+  label: string;
+  options: Array<{ label: string; value: string }>;
+  value: string;
+  onChange: (value: string) => void;
+  labelHidden?: boolean;
+}) {
+  const id = useId();
+  return (
+    <div style={{ display: "grid", gap: "0.35rem" }}>
+      {!labelHidden ? <label htmlFor={id}>{label}</label> : <label htmlFor={id} style={{ position: "absolute", left: "-9999px" }}>{label}</label>}
+      <select
+        id={id}
+        value={value}
+        onChange={(event) => onChange(event.currentTarget.value)}
+        style={{
+          width: "100%",
+          padding: "0.75rem",
+          borderRadius: "0.75rem",
+          border: "1px solid var(--p-color-border, #d2d5d8)",
+          font: "inherit",
+        }}
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+type ModalAction = {
+  content: string;
+  onAction: () => void;
+  disabled?: boolean;
+  destructive?: boolean;
+  loading?: boolean;
+};
+
+function ModalSection({ children }: { children: ReactNode }) {
+  return <div>{children}</div>;
+}
+
+export function Modal({
+  open,
+  onClose,
+  title,
+  primaryAction,
+  secondaryActions = [],
+  children,
+}: {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  primaryAction?: ModalAction;
+  secondaryActions?: Array<{ content: string; onAction: () => void }>;
+  children: ReactNode;
+}) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (open && !dialog.open) dialog.showModal();
+    if (!open && dialog.open) dialog.close();
+  }, [open]);
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClose={onClose}
+      style={{
+        border: "none",
+        borderRadius: "1rem",
+        padding: 0,
+        maxWidth: "40rem",
+        width: "calc(100% - 2rem)",
+      }}
+    >
+      <div style={{ padding: "1.5rem", display: "grid", gap: "1rem" }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: "1rem", alignItems: "start" }}>
+          <strong>{title}</strong>
+          <button
+            type="button"
+            aria-label="Close dialog"
+            onClick={onClose}
+            style={{ border: "none", background: "transparent", fontSize: "1.5rem", lineHeight: 1, cursor: "pointer" }}
+          >
+            ×
+          </button>
+        </div>
+        {children}
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: "0.75rem", flexWrap: "wrap" }}>
+          {secondaryActions.map((action) => (
+            <Button key={action.content} variant="plain" onClick={action.onAction}>
+              {action.content}
+            </Button>
+          ))}
+          {primaryAction ? (
+            <Button
+              variant="primary"
+              tone={primaryAction.destructive ? "critical" : undefined}
+              disabled={primaryAction.disabled}
+              loading={primaryAction.loading}
+              onClick={primaryAction.onAction}
+            >
+              {primaryAction.content}
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    </dialog>
+  );
+}
+
+Modal.Section = ModalSection;
+
+export function EmptyState({
+  heading,
+  children,
+  fullWidth,
+}: {
+  heading: string;
+  image?: string;
+  children: ReactNode;
+  fullWidth?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        border: "1px dashed var(--p-color-border, #d2d5d8)",
+        borderRadius: "1rem",
+        padding: "1.25rem",
+        display: "grid",
+        gap: "0.75rem",
+      }}
+    >
+      <strong>{heading}</strong>
+      {children}
+    </div>
+  );
+}
+
+type AutocompleteOption = { value: string; label: string };
+
+function AutocompleteTextField(props: Parameters<typeof TextField>[0]) {
+  return <TextField {...props} />;
+}
+
+export function Autocomplete({
+  options,
+  onSelect,
+  textField,
+  emptyState,
+}: {
+  options: AutocompleteOption[];
+  selected: string[];
+  onSelect: (selected: string[]) => void;
+  textField: ReactNode;
+  emptyState?: ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handlePointerDown(event: MouseEvent) {
+      if (!wrapperRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, []);
+
+  return (
+    <div
+      ref={wrapperRef}
+      style={{ position: "relative" }}
+      onFocusCapture={() => setOpen(true)}
+      onClickCapture={() => setOpen(true)}
+    >
+      {textField}
+      {open && (
+        <div
+          style={{
+            position: "absolute",
+            top: "calc(100% + 0.35rem)",
+            left: 0,
+            right: 0,
+            zIndex: 20,
+            border: "1px solid var(--p-color-border, #d2d5d8)",
+            borderRadius: "0.75rem",
+            overflow: "hidden",
+            maxHeight: "14rem",
+            overflowY: "auto",
+            background: "#fff",
+            boxShadow: "0 12px 24px rgba(0, 0, 0, 0.12)",
+          }}
+        >
+          {options.length === 0 ? (
+            <div style={{ padding: "0.75rem 1rem" }}>{emptyState ?? null}</div>
+          ) : (
+            options.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => {
+                  onSelect([option.value]);
+                  setOpen(false);
+                }}
+                style={{
+                  width: "100%",
+                  textAlign: "left",
+                  border: 0,
+                  background: "#fff",
+                  padding: "0.75rem 1rem",
+                  cursor: "pointer",
+                }}
+              >
+                {option.label}
+              </button>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+Autocomplete.TextField = AutocompleteTextField;

--- a/app/globals.d.ts
+++ b/app/globals.d.ts
@@ -55,6 +55,8 @@ declare global {
       "s-table-header-row": ShopifyElementProps;
       "s-table-row": ShopifyElementProps;
       "s-text-field": ShopifyElementProps;
+      "ui-nav-menu": ShopifyElementProps;
+      "ui-save-bar": ShopifyElementProps;
       "ui-title-bar": DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> & {
         title?: string;
       };

--- a/app/routes/app.equipment.tsx
+++ b/app/routes/app.equipment.tsx
@@ -216,7 +216,7 @@ export default function EquipmentPage() {
   return (
     <>
       <ui-title-bar title="Equipment Library">
-        <button variant="primary" onClick={openCreate}>New equipment</button>
+        <button type="button" onClick={openCreate}>New equipment</button>
       </ui-title-bar>
 
       <div

--- a/app/routes/app.materials.tsx
+++ b/app/routes/app.materials.tsx
@@ -257,7 +257,7 @@ export default function MaterialsPage() {
   return (
     <>
       <ui-title-bar title="Material Library">
-        <button variant="primary" onClick={openCreate}>New material</button>
+        <button type="button" onClick={openCreate}>New material</button>
       </ui-title-bar>
 
       <div

--- a/app/routes/app.templates.$templateId.tsx
+++ b/app/routes/app.templates.$templateId.tsx
@@ -15,8 +15,8 @@ import {
   Page,
   Text,
   TextField,
-} from "@shopify/polaris";
-import { TitleBar } from "@shopify/app-bridge-react";
+  TitleBar,
+} from "../components/polaris-shim";
 import { z } from "zod";
 import { AppSaveBar } from "../components/AppSaveBar";
 import { prisma } from "../db.server";

--- a/app/routes/app.templates._index.tsx
+++ b/app/routes/app.templates._index.tsx
@@ -159,7 +159,7 @@ export default function TemplatesPage() {
   return (
     <>
       <ui-title-bar title="Cost Templates">
-        <button variant="primary" onClick={openCreateDialog}>New template</button>
+        <button type="button" onClick={openCreateDialog}>New template</button>
       </ui-title-bar>
 
       <div

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -1,15 +1,11 @@
 import type { HeadersFunction, LoaderFunctionArgs } from "@remix-run/node";
-import { Link, Outlet, useLoaderData, useRouteError } from "@remix-run/react";
+import { Outlet, useLoaderData, useRouteError } from "@remix-run/react";
 import { boundary } from "@shopify/shopify-app-remix/server";
 import { AppProvider } from "@shopify/shopify-app-remix/react";
-import { NavMenu } from "@shopify/app-bridge-react";
-import polarisStyles from "@shopify/polaris/build/esm/styles.css?url";
 
 import { prisma } from "../db.server";
 import { authenticate } from "../shopify.server";
 import { getLocaleFromRequest } from "../utils/localization.server";
-
-export const links = () => [{ rel: "stylesheet", href: polarisStyles }];
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -43,28 +39,20 @@ export default function App() {
   return (
     <AppProvider isEmbeddedApp apiKey={apiKey}>
       {/* Navigation renders in the Shopify admin sidebar */}
-      <NavMenu>
-        <Link to="/app/dashboard" rel="home">Dashboard</Link>
-        <Link to="/app/settings">Settings</Link>
-
-        {/* Cost Config */}
-        <Link to="/app/materials">Materials</Link>
-        <Link to="/app/equipment">Equipment</Link>
-        <Link to="/app/templates">Cost Templates</Link>
-        <Link to="/app/variants">Variants</Link>
-
-        {/* Donation Setup */}
-        <Link to="/app/causes">Causes</Link>
-        <Link to="/app/products">Products</Link>
-
-        {/* Finance */}
-        <Link to="/app/reporting">Reporting</Link>
-        <Link to="/app/expenses">Expenses</Link>
-
-        {/* Operations */}
-        <Link to="/app/provider-connections">Provider Connections</Link>
-        <Link to="/app/order-history">Order History</Link>
-      </NavMenu>
+      <ui-nav-menu>
+        <a href="/app/dashboard" rel="home">Dashboard</a>
+        <a href="/app/settings">Settings</a>
+        <a href="/app/materials">Materials</a>
+        <a href="/app/equipment">Equipment</a>
+        <a href="/app/templates">Cost Templates</a>
+        <a href="/app/variants">Variants</a>
+        <a href="/app/causes">Causes</a>
+        <a href="/app/products">Products</a>
+        <a href="/app/reporting">Reporting</a>
+        <a href="/app/expenses">Expenses</a>
+        <a href="/app/provider-connections">Provider Connections</a>
+        <a href="/app/order-history">Order History</a>
+      </ui-nav-menu>
       <Outlet />
     </AppProvider>
   );

--- a/app/routes/app.variants.$variantId.tsx
+++ b/app/routes/app.variants.$variantId.tsx
@@ -14,8 +14,8 @@ import {
   Select,
   Text,
   TextField,
-} from "@shopify/polaris";
-import { TitleBar } from "@shopify/app-bridge-react";
+  TitleBar,
+} from "../components/polaris-shim";
 import { z } from "zod";
 import { AppSaveBar } from "../components/AppSaveBar";
 import { authenticate } from "../shopify.server";

--- a/app/utils/use-unsaved-changes-guard.ts
+++ b/app/utils/use-unsaved-changes-guard.ts
@@ -19,7 +19,7 @@ export function useUnsavedChangesGuard(isDirty: boolean) {
   const confirmThenNavigate = useCallback(
     async (to: string) => {
       if (isDirty) {
-        await globalThis.shopify?.saveBar?.leaveConfirmation?.();
+        await (globalThis as any).shopify?.saveBar?.leaveConfirmation?.();
       }
 
       navigate(to);

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,6 @@
         "@remix-run/node": "^2.16.1",
         "@remix-run/react": "^2.16.1",
         "@remix-run/serve": "^2.16.1",
-        "@shopify/app-bridge-react": "^4.1.6",
-        "@shopify/polaris": "^12.0.0",
         "@shopify/shopify-app-remix": "^4.1.0",
         "@shopify/shopify-app-session-storage-prisma": "^9.0.0",
         "isbot": "^5.1.0",
@@ -4332,28 +4330,6 @@
         "graphql": "^16.10.0"
       }
     },
-    "node_modules/@shopify/app-bridge-react": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@shopify/app-bridge-react/-/app-bridge-react-4.2.10.tgz",
-      "integrity": "sha512-/VhfsxIvWcK7w5rBY97WdSTApLEg+Z2dT9Zc+idAUiAi48R64nYalXDUG8ar5xRoINHFC/w+9WxYViAazpgfew==",
-      "license": "MIT",
-      "dependencies": {
-        "@shopify/app-bridge-types": "0.7.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@shopify/app-bridge-types": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@shopify/app-bridge-types/-/app-bridge-types-0.7.0.tgz",
-      "integrity": "sha512-A/DiGIjCBdd45ijMDKLgXrrGG68so3d25Yaeo0lv8ruWeljHGn3sA+UU1o/5BptSPkikDkgPPl8EQDxe4/KShw==",
-      "license": "ISC",
-      "dependencies": {
-        "@standard-schema/spec": "^1.0.0"
-      }
-    },
     "node_modules/@shopify/graphql-client": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@shopify/graphql-client/-/graphql-client-1.4.2.tgz",
@@ -4426,6 +4402,8 @@
       "resolved": "https://registry.npmjs.org/@shopify/polaris/-/polaris-12.27.0.tgz",
       "integrity": "sha512-Y8yus6iEjcfW2ZtEJtlqxbWeDJqTX3S/MOLH4GWRvU5gFYJQhlaHaETs0+OimbhEpO95mXbY8qB+KnIJaVBHwA==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@shopify/polaris-icons": "^8.11.1",
         "@shopify/polaris-tokens": "^8.10.0",
@@ -4448,6 +4426,8 @@
       "resolved": "https://registry.npmjs.org/@shopify/polaris-icons/-/polaris-icons-8.11.1.tgz",
       "integrity": "sha512-2HLzvJWMejKIwS5P2bs7k5CAjBKwPnD/iy9ncPzcgqRjmFInBXLtUXFQhPWDw6JwXzb1ZjNQK/ssTctcfz87Sw==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^16.17.0 || >=18.12.0"
       },
@@ -4465,6 +4445,8 @@
       "resolved": "https://registry.npmjs.org/@shopify/polaris-tokens/-/polaris-tokens-8.10.0.tgz",
       "integrity": "sha512-y4PDtRbFKGHwA6Lu7a3L4N9SDP6gZv4tw6u0viumtcXcbF0T2j1xPmyuJZNc9c7vmhNSARCg27NGQFpPgxuaEg==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "deepmerge": "^4.3.1"
       },
@@ -4729,12 +4711,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -4745,6 +4729,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -4755,6 +4740,8 @@
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
       "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "peerDependencies": {
         "@types/react": "*"
       }
@@ -7422,6 +7409,8 @@
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
       "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
@@ -12862,6 +12851,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13939,6 +13929,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -13950,6 +13941,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/property-information": {
@@ -14137,7 +14129,9 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/react-is": {
       "version": "17.0.2",
@@ -14192,6 +14186,8 @@
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
       "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,6 @@
     "@remix-run/node": "^2.16.1",
     "@remix-run/react": "^2.16.1",
     "@remix-run/serve": "^2.16.1",
-    "@shopify/app-bridge-react": "^4.1.6",
-    "@shopify/polaris": "^12.0.0",
     "@shopify/shopify-app-remix": "^4.1.0",
     "@shopify/shopify-app-session-storage-prisma": "^9.0.0",
     "isbot": "^5.1.0",


### PR DESCRIPTION
## Summary
- finish removing @shopify/polaris and @shopify/app-bridge-react from the app
- add a local shim for the remaining complex template and variant detail surfaces
- tighten the shim autocomplete behavior so search results only open on field focus/click and render as an overlay

## Validation
- npx tsc --noEmit
- npm run lint
- npm test