### PR TITLE
Prepare Phase 3 kickoff planning docs

### DIFF
--- a/docs/current-implementation-status.md
+++ b/docs/current-implementation-status.md
@@ -5,16 +5,16 @@ Use this document as the practical snapshot of what is implemented in the repo t
 This file is intentionally lightweight and operational. It should summarize reality, not restate full product requirements or phase specs.
 
 **Project:** Count On Us  
-**Date:** April 2, 2026  
-**Summary:** Phase 1 is complete. Phase 2 is largely implemented and currently being hardened. The team is wrapping up pre-Phase-3 issues before beginning the immutable snapshot, causes, and order accounting work.
+**Date:** April 4, 2026  
+**Summary:** Phase 1 and Phase 2 are complete. The pre-Phase-3 hardening pass is complete, including the Polaris Web Components migration and the first Playwright workflow coverage. The project is now preparing to begin Phase 3 implementation.
 
 ---
 
 ## Current Position
 
 - **Phase 1:** Complete
-- **Phase 2:** Mostly complete
-- **Current focus:** Phase 2 hardening and pre-Phase-3 cleanup
+- **Phase 2:** Complete
+- **Current focus:** Phase 3 preparation and kickoff planning
 - **Phase 3:** Not yet started in substantive backend/data-model terms
 
 ---
@@ -52,31 +52,41 @@ This file is intentionally lightweight and operational. It should summarize real
 - [x] Default labor rate groundwork
 - [x] Currency/localization groundwork
 
-### Still being hardened
+### Hardening completed during Phase 2 exit work
 
-- [~] Audit logging is present across many flows, but should be spot-checked against all documented required mutations
-- [~] Validation exists in many actions, but is not yet consistently standardized around Zod
-- [~] CostEngine behavior is implemented, but documented unit-test expectations do not appear fully in place
-- [~] Template and variant UX is still being refined as part of Phase 2 wrap-up
+- [x] Staged save/discard UX for template and variant details
+- [x] Searchable picker pattern on template and variant editors
+- [x] Currency and locale formatting rollout
+- [x] Default labor rate rollout
+- [x] Shipping-material costing behavior aligned with intended rules
+- [x] Polaris Web Components migration off Shopify React dependencies
+- [x] Playwright foundation plus real workflow coverage for key Phase 2 surfaces
 
 ### Deferred or intentionally incomplete
 
 - [ ] POD/provider connections
 - [ ] Full inline bulk editor
-- [ ] Formal Vitest setup and documented test scripts
+- [ ] Full design revisit for large-list filtering UX
 
 ---
 
-## Pre-Phase-3 Cleanup Checklist
+## Phase 2 Exit Checklist
 
-- [ ] Finish remaining Phase 2 amendment work on templates and variants
-- [ ] Clean up hardcoded localization defaults and connect formatter inputs to real shop data
-- [ ] Verify shipping-material costing behavior matches the intended rules
-- [ ] Verify default labor rate fallback everywhere costs are resolved
-- [ ] Confirm `lineItemCount` stays correct through all add/remove paths
-- [ ] Replace temporary webhook behavior that should not carry into Phase 3
-- [ ] Add or finish automated tests for CostEngine and critical validation paths
-- [ ] Reconcile docs and code before starting Phase 3 implementation
+- [x] Finish remaining Phase 2 amendment work on templates and variants
+- [x] Connect localization and formatter inputs to real shop data
+- [x] Verify shipping-material costing behavior matches the intended rules
+- [x] Verify default labor rate fallback in cost resolution
+- [x] Confirm `lineItemCount` stays correct through add/remove paths
+- [x] Replace temporary React-based admin UI dependencies
+- [x] Add automated tests for CostEngine regressions and critical UI workflows
+- [x] Reconcile docs and code before starting Phase 3 implementation
+
+## Phase 3 Readiness Notes
+
+- Shopify scopes already include `read_orders`, `read_metaobjects`, `write_metaobjects`, and `write_products`.
+- `shopify.app.toml` does not yet include the Phase 3 order webhook subscriptions for `orders/create`, `orders/updated`, and `refunds/create`.
+- Phase 3 placeholder routes already exist for `Causes`, `Products`, `Expenses`, and `Order History`, but substantive backend/data-model work has not begun.
+- Prisma schema is still Phase 2 only; no causes, snapshots, adjustments, business expenses, or tax-offset models exist yet.
 
 ---
 
@@ -134,4 +144,5 @@ This file is intentionally lightweight and operational. It should summarize real
 
 - This file is a practical implementation snapshot, not the source of product requirements.
 - The PRD, build plan, ADRs, and implementation plans remain authoritative for scope and architecture.
+- For immediate next work, use `docs/plans/phase-3-kickoff-checklist.md` alongside the Phase 3 implementation plan.
 - Update this file when a phase meaningfully changes state, not for every small commit.

--- a/docs/plans/phase-3-implementation-plan.md
+++ b/docs/plans/phase-3-implementation-plan.md
@@ -26,6 +26,20 @@ PU-3 in particular affects what `CostEngine` and `SnapshotService` read from the
 
 ---
 
+## Readiness update
+
+Phase 2 exit work is complete. Phase 3 should assume the following baseline is already in place:
+
+- staged save/discard UX on template and variant detail routes
+- searchable picker flows on template and variant editors
+- default labor rate and shared currency/locale formatting
+- Polaris Web Components migration off Shopify React dependencies
+- Playwright coverage for template details, variant details, and variants bulk assignment workflows
+
+The pre-Phase-3 amendment list below should be treated as historical context, not remaining blocker work.
+
+---
+
 ## Scoping decisions
 
 - **POD deferred:** CostEngine POD step remains stubbed at `Decimal(0)`. `OrderSnapshotPODLine` schema is added in this phase but no rows will be written. `pod_cost_estimated` and `pod_cost_missing` flags are for when POD is configured but unavailable — they are not set when POD is simply not configured.

--- a/docs/plans/phase-3-kickoff-checklist.md
+++ b/docs/plans/phase-3-kickoff-checklist.md
@@ -1,0 +1,180 @@
+# Phase 3 Kickoff Checklist
+
+Use this document as the practical start-of-work checklist for Phase 3.
+
+It complements `phase-3-implementation-plan.md` by breaking the first tranche into concrete prep, verification, and sequencing steps for the current repo state.
+
+## Current baseline
+
+Before starting Phase 3 implementation, the repo already has:
+
+- completed Phase 2 cost model flows
+- staged save/discard on template and variant detail pages
+- shared localization wired to shop currency and request locale
+- migration off Shopify React dependencies
+- Playwright coverage for:
+  - template details save/discard
+  - variant details save/discard
+  - variants bulk assignment
+
+## Remaining preparation tasks
+
+These should happen before the first substantive Phase 3 feature branch is opened.
+
+### 1. Confirm `main` is stable
+
+- Run `npx tsc --noEmit`
+- Run `npm run lint`
+- Run `npm test`
+- Run `npm run test:ui`
+- Smoke test in Shopify admin:
+  - Materials add/edit/deactivate
+  - Equipment add/edit/deactivate
+  - Template details save/discard
+  - Variant details save/discard
+  - Variants bulk assignment
+
+### 2. Update Shopify app configuration
+
+Current scopes already cover:
+
+- `read_orders`
+- `read_metaobjects`
+- `write_metaobjects`
+- `write_products`
+
+Still needed:
+
+- add webhook subscriptions for:
+  - `orders/create`
+  - `orders/updated`
+  - `refunds/create`
+- verify whether any additional scope or approval is required for protected customer data handling before production rollout
+
+### 3. Lock the Phase 3 branch strategy
+
+Recommended first tranche:
+
+1. Prisma schema and tenant scoping
+2. Cause metaobject definition and Cause CRUD
+3. Product cause assignment and product metafield sync
+4. Snapshot schema-adjacent service scaffolding
+5. Order webhook and job wiring
+
+Do not start with:
+
+- order history UI
+- reconciliation job
+- business expenses UI
+
+Those depend on the snapshot data model being stable first.
+
+## Recommended implementation order
+
+### Tranche A: Data model foundation
+
+- Add Phase 3 Prisma models:
+  - `Cause`
+  - `ProductCauseAssignment`
+  - `OrderSnapshot`
+  - `OrderSnapshotLine`
+  - `OrderSnapshotMaterialLine`
+  - `OrderSnapshotEquipmentLine`
+  - `OrderSnapshotPODLine`
+  - `LineCauseAllocation`
+  - `Adjustment`
+  - `BusinessExpense`
+  - `TaxOffsetCache`
+- Update `app/db.server.ts` tenant model allowlist
+- Run migration and regenerate Prisma client
+
+Exit check:
+
+- schema migrates cleanly
+- Prisma client compiles
+- tenant guardrails still work as expected
+
+### Tranche B: Cause foundation
+
+- Add Cause metaobject definition bootstrap service
+- Hook definition creation into install flow
+- Implement `app.causes.tsx` for cause management
+- Add audit logging for cause create/update/status changes
+
+Exit check:
+
+- creating a Cause writes both local DB record and Shopify metaobject
+- updating a Cause updates both systems
+- inactive causes are preserved correctly
+
+### Tranche C: Product donation assignment
+
+- Implement product-level cause assignment route
+- Validate percentage totals
+- Sync assignment metafield to Shopify product
+
+Exit check:
+
+- a product can be assigned one or more causes
+- totals over 100% are rejected
+- metafield payload matches stored DB assignments
+
+### Tranche D: Snapshot scaffolding
+
+- Add `SnapshotService` shell
+- Add packaging allocation contract into `CostEngine`
+- Define snapshot creation inputs and idempotency rules
+- Add initial unit tests for:
+  - idempotency
+  - packaging override path
+  - cause allocation math
+
+Exit check:
+
+- service compiles and is test-covered before webhook wiring begins
+
+### Tranche E: Webhook and job wiring
+
+- add order webhook subscriptions
+- wire `orders/create`, `orders/updated`, `refunds/create`
+- add job queue processors for snapshot and adjustment flows
+
+Exit check:
+
+- webhook handlers enqueue jobs correctly
+- duplicate deliveries do not produce duplicate snapshots
+
+## Testing expectations
+
+Phase 3 should raise the testing bar further than Phase 2.
+
+Add or expand:
+
+- Vitest coverage for:
+  - snapshot math
+  - packaging allocation
+  - cause allocation percentages
+  - refund proportional adjustments
+  - tax offset cache updates
+- Playwright coverage when Phase 3 introduces:
+  - new staged editors
+  - new modal-driven admin workflows
+  - new list selection or bulk-action patterns
+
+For embedded Shopify shell integrations, keep a short manual verification checklist even when Playwright is green.
+
+## Suggested first branch
+
+Recommended first implementation branch name:
+
+- `phase-3-tranche-a-schema-foundation`
+
+Suggested scope for that branch only:
+
+- Prisma schema
+- Prisma migration
+- tenant model registration
+- any required generated client updates
+- no route/UI work yet
+
+Keeping the first branch data-model-only will reduce merge risk and give the rest of Phase 3 a clean foundation.


### PR DESCRIPTION
## Summary
- refresh current implementation status to reflect that Phase 2 exit work is complete
- add a Phase 3 readiness update to the implementation plan
- add a practical kickoff checklist for the first Phase 3 implementation tranche

## Testing
- not run (docs-only changes)