### PR TITLE
Allow deleting unused records safely

### DIFF
--- a/app/routes/app.causes.tsx
+++ b/app/routes/app.causes.tsx
@@ -6,6 +6,7 @@ import { HelpText } from "../components/HelpText";
 import { prisma } from "../db.server";
 import {
   createCauseMetaobject,
+  deleteCauseMetaobject,
   ensureCauseMetaobjectDefinition,
   updateCauseMetaobject,
 } from "../services/causeMetaobjectService.server";
@@ -56,6 +57,7 @@ type CauseRecord = {
   status: string;
   metaobjectId: string | null;
   assignmentCount: number;
+  lineAllocationCount: number;
 };
 
 type CauseActionData = {
@@ -85,7 +87,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     orderBy: { name: "asc" },
     include: {
       _count: {
-        select: { productAssignments: true },
+        select: { productAssignments: true, lineAllocations: true },
       },
     },
   });
@@ -104,6 +106,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       status: cause.status,
       metaobjectId: cause.shopifyMetaobjectId,
       assignmentCount: cause._count.productAssignments,
+      lineAllocationCount: cause._count.lineAllocations,
     })),
   });
 };
@@ -458,6 +461,96 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     }
   }
 
+  if (intent === "delete") {
+    const idParsed = causeIdSchema.safeParse({
+      id: formData.get("id")?.toString() ?? "",
+    });
+
+    if (!idParsed.success) {
+      return Response.json(
+        { ok: false, message: idParsed.error.issues[0]?.message ?? "Invalid Cause." },
+        { status: 400 },
+      );
+    }
+
+    const cause = await prisma.cause.findFirst({
+      where: { id: idParsed.data.id, shopId },
+      include: {
+        _count: {
+          select: { productAssignments: true, lineAllocations: true },
+        },
+      },
+    });
+
+    if (!cause) {
+      return Response.json({ ok: false, message: "Cause not found." }, { status: 404 });
+    }
+
+    if (cause._count.productAssignments > 0 || cause._count.lineAllocations > 0) {
+      return Response.json(
+        {
+          ok: false,
+          message:
+            cause._count.lineAllocations > 0
+              ? `This Cause appears in ${cause._count.lineAllocations} historical line allocation(s) and cannot be deleted.`
+              : `This Cause is still assigned to ${cause._count.productAssignments} product(s). Remove those assignments before deleting it.`,
+        },
+        { status: 400 },
+      );
+    }
+
+    await prisma.cause.delete({
+      where: { id: cause.id, shopId },
+    });
+
+    await prisma.auditLog.create({
+      data: {
+        shopId,
+        entity: "Cause",
+        entityId: cause.id,
+        action: "CAUSE_DELETED",
+        actor: "merchant",
+        payload: { shopifyMetaobjectId: cause.shopifyMetaobjectId },
+      },
+    });
+
+    if (admin && cause.shopifyMetaobjectId) {
+      try {
+        await deleteCauseMetaobject(admin, cause.shopifyMetaobjectId);
+        await prisma.auditLog.create({
+          data: {
+            shopId,
+            entity: "Cause",
+            entityId: cause.id,
+            action: "CAUSE_SHOPIFY_DELETED",
+            actor: "merchant",
+            payload: { shopifyMetaobjectId: cause.shopifyMetaobjectId },
+          },
+        });
+      } catch (error) {
+        await prisma.auditLog.create({
+          data: {
+            shopId,
+            entity: "Cause",
+            entityId: cause.id,
+            action: "CAUSE_SHOPIFY_DELETE_FAILED",
+            actor: "merchant",
+            payload: {
+              shopifyMetaobjectId: cause.shopifyMetaobjectId,
+              message: error instanceof Error ? error.message : "Unknown Shopify delete failure",
+            },
+          },
+        });
+        return Response.json(
+          { ok: false, message: "Cause deleted locally, but Shopify cleanup failed." },
+          { status: 502 },
+        );
+      }
+    }
+
+    return Response.json({ ok: true, message: "Cause deleted." });
+  }
+
   return Response.json({ ok: false, message: "Unknown action." }, { status: 400 });
 };
 
@@ -466,11 +559,14 @@ export default function CausesPage() {
   const fetcher = useFetcher<CauseActionData>();
   const causeDialogRef = useRef<HTMLDialogElement>(null);
   const deactivateDialogRef = useRef<HTMLDialogElement>(null);
+  const deleteDialogRef = useRef<HTMLDialogElement>(null);
 
   const [form, setForm] = useState<CauseFormState>(EMPTY_FORM);
   const [causeDialogOpen, setCauseDialogOpen] = useState(false);
   const [deactivateDialogOpen, setDeactivateDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deactivateTarget, setDeactivateTarget] = useState<CauseRecord | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<CauseRecord | null>(null);
   const [lastSubmittedIntent, setLastSubmittedIntent] = useState<string | null>(null);
 
   useEffect(() => {
@@ -494,6 +590,17 @@ export default function CausesPage() {
       dialog.close();
     }
   }, [deactivateDialogOpen]);
+
+  useEffect(() => {
+    const dialog = deleteDialogRef.current;
+    if (!dialog) return;
+
+    if (deleteDialogOpen && !dialog.open) {
+      dialog.showModal();
+    } else if (!deleteDialogOpen && dialog.open) {
+      dialog.close();
+    }
+  }, [deleteDialogOpen]);
 
   function updateForm<K extends keyof CauseFormState>(key: K, value: CauseFormState[K]) {
     setForm((current) => ({ ...current, [key]: value }));
@@ -532,10 +639,23 @@ export default function CausesPage() {
     setDeactivateDialogOpen(true);
   }
 
+  function confirmDelete(cause: CauseRecord) {
+    setDeleteTarget(cause);
+    setDeleteDialogOpen(true);
+  }
+
   const closeDeactivateDialog = useCallback(() => {
     setDeactivateDialogOpen(false);
     setDeactivateTarget(null);
     if (lastSubmittedIntent === "deactivate") {
+      setLastSubmittedIntent(null);
+    }
+  }, [lastSubmittedIntent]);
+
+  const closeDeleteDialog = useCallback(() => {
+    setDeleteDialogOpen(false);
+    setDeleteTarget(null);
+    if (lastSubmittedIntent === "delete") {
       setLastSubmittedIntent(null);
     }
   }, [lastSubmittedIntent]);
@@ -550,7 +670,10 @@ export default function CausesPage() {
     if (lastSubmittedIntent === "deactivate" || lastSubmittedIntent === "reactivate") {
       closeDeactivateDialog();
     }
-  }, [fetcher.state, fetcher.data, lastSubmittedIntent, closeCauseDialog, closeDeactivateDialog]);
+    if (lastSubmittedIntent === "delete") {
+      closeDeleteDialog();
+    }
+  }, [fetcher.state, fetcher.data, lastSubmittedIntent, closeCauseDialog, closeDeactivateDialog, closeDeleteDialog]);
 
   const isSubmitting = fetcher.state !== "idle";
   const statusMessage = fetcher.data?.message ?? "";
@@ -559,7 +682,7 @@ export default function CausesPage() {
     [fetcher.data?.fieldErrors, lastSubmittedIntent],
   );
   const showPageError =
-    fetcher.data && !fetcher.data.ok && !(lastSubmittedIntent === "create" || lastSubmittedIntent === "update" || lastSubmittedIntent === "deactivate");
+    fetcher.data && !fetcher.data.ok && !(lastSubmittedIntent === "create" || lastSubmittedIntent === "update" || lastSubmittedIntent === "deactivate" || lastSubmittedIntent === "delete");
   const showPageSuccess = fetcher.data?.ok && lastSubmittedIntent === "reactivate";
 
   function fieldError(name: keyof Omit<CauseFormState, "id">) {
@@ -678,6 +801,9 @@ export default function CausesPage() {
                             </s-button>
                           </fetcher.Form>
                         )}
+                        <s-button variant="secondary" tone="critical" onClick={() => confirmDelete(cause)}>
+                          Delete
+                        </s-button>
                       </div>
                     </s-table-cell>
                   </s-table-row>
@@ -942,6 +1068,82 @@ export default function CausesPage() {
               }}
             >
               Deactivate
+            </s-button>
+          </div>
+        </div>
+      </dialog>
+
+      <dialog
+        ref={deleteDialogRef}
+        onClose={closeDeleteDialog}
+        style={{
+          border: "none",
+          borderRadius: "1rem",
+          padding: 0,
+          maxWidth: "34rem",
+          width: "calc(100% - 2rem)",
+        }}
+      >
+        <div style={{ padding: "1.5rem", display: "grid", gap: "1rem" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: "1rem", alignItems: "start" }}>
+            <div style={{ display: "grid", gap: "0.25rem" }}>
+              <strong>Delete cause</strong>
+              <s-text color="subdued">Delete this Cause permanently only if it is not assigned to products and has no historical allocations.</s-text>
+            </div>
+            <button
+              type="button"
+              aria-label="Close dialog"
+              onClick={closeDeleteDialog}
+              style={{
+                border: "none",
+                background: "transparent",
+                fontSize: "1.5rem",
+                lineHeight: 1,
+                cursor: "pointer",
+              }}
+            >
+              Ã—
+            </button>
+          </div>
+
+          {fetcher.data && !fetcher.data.ok && lastSubmittedIntent === "delete" ? (
+            <s-banner tone="critical">
+              <s-text>{fetcher.data.message}</s-text>
+            </s-banner>
+          ) : null}
+
+          <s-text>
+            {deleteTarget
+              ? `Delete ${deleteTarget.name} permanently? This cannot be undone.`
+              : "Delete this Cause permanently?"}
+          </s-text>
+
+          {deleteTarget && (deleteTarget.assignmentCount > 0 || deleteTarget.lineAllocationCount > 0) ? (
+            <s-banner tone="warning">
+              <s-text>
+                {deleteTarget.lineAllocationCount > 0
+                  ? `This Cause appears in ${deleteTarget.lineAllocationCount} historical allocation(s), so deletion is blocked.`
+                  : `This Cause is still assigned to ${deleteTarget.assignmentCount} product(s), so deletion is blocked.`}
+              </s-text>
+            </s-banner>
+          ) : null}
+
+          <div style={{ display: "flex", justifyContent: "flex-end", gap: "0.75rem", flexWrap: "wrap" }}>
+            <s-button variant="secondary" onClick={closeDeleteDialog}>Cancel</s-button>
+            <s-button
+              variant="primary"
+              tone="critical"
+              disabled={isSubmitting || ((deleteTarget?.assignmentCount ?? 0) > 0 || (deleteTarget?.lineAllocationCount ?? 0) > 0)}
+              onClick={() => {
+                if (!deleteTarget) return;
+                const fd = new FormData();
+                fd.append("intent", "delete");
+                fd.append("id", deleteTarget.id);
+                setLastSubmittedIntent("delete");
+                fetcher.submit(fd, { method: "post" });
+              }}
+            >
+              Delete
             </s-button>
           </div>
         </div>

--- a/app/routes/app.equipment.tsx
+++ b/app/routes/app.equipment.tsx
@@ -1,9 +1,14 @@
 import { useEffect, useRef, useState } from "react";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { useFetcher, useLoaderData, useRouteError } from "@remix-run/react";
+import { z } from "zod";
 import { prisma } from "../db.server";
 import { authenticateAdminRequest } from "../utils/admin-auth.server";
 import { useAppLocalization } from "../utils/use-app-localization";
+
+const equipmentIdSchema = z.object({
+  id: z.string().trim().cuid("Equipment id is invalid."),
+});
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticateAdminRequest(request);
@@ -101,7 +106,11 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   }
 
   if (intent === "deactivate" || intent === "reactivate") {
-    const id = formData.get("id")?.toString() ?? "";
+    const parsed = equipmentIdSchema.safeParse({ id: formData.get("id")?.toString() ?? "" });
+    if (!parsed.success) {
+      return Response.json({ ok: false, message: parsed.error.issues[0]?.message ?? "Invalid equipment." }, { status: 400 });
+    }
+    const id = parsed.data.id;
     const status = intent === "deactivate" ? "inactive" : "active";
     await prisma.equipmentLibraryItem.update({ where: { id, shopId }, data: { status } });
     await prisma.auditLog.create({
@@ -117,6 +126,47 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       ok: true,
       message: intent === "deactivate" ? "Equipment deactivated." : "Equipment reactivated.",
     });
+  }
+
+  if (intent === "delete") {
+    const parsed = equipmentIdSchema.safeParse({ id: formData.get("id")?.toString() ?? "" });
+    if (!parsed.success) {
+      return Response.json({ ok: false, message: parsed.error.issues[0]?.message ?? "Invalid equipment." }, { status: 400 });
+    }
+
+    const item = await prisma.equipmentLibraryItem.findFirst({
+      where: { id: parsed.data.id, shopId },
+      include: {
+        _count: { select: { templateLines: true, variantLines: true } },
+      },
+    });
+
+    if (!item) {
+      return Response.json({ ok: false, message: "Equipment not found." }, { status: 404 });
+    }
+
+    if (item._count.templateLines > 0 || item._count.variantLines > 0) {
+      return Response.json(
+        {
+          ok: false,
+          message: `This equipment is still used in ${item._count.templateLines} template(s) and ${item._count.variantLines} variant config(s). Remove those references before deleting it.`,
+        },
+        { status: 400 },
+      );
+    }
+
+    await prisma.equipmentLibraryItem.delete({ where: { id: item.id, shopId } });
+    await prisma.auditLog.create({
+      data: {
+        shopId,
+        entity: "EquipmentLibraryItem",
+        entityId: item.id,
+        action: "EQUIPMENT_DELETED",
+        actor: "merchant",
+      },
+    });
+
+    return Response.json({ ok: true, message: "Equipment deleted." });
   }
 
   return Response.json({ ok: false, message: "Unknown action." }, { status: 400 });
@@ -147,11 +197,15 @@ export default function EquipmentPage() {
   const { formatMoney, getCurrencySymbol } = useAppLocalization();
   const equipmentDialogRef = useRef<HTMLDialogElement>(null);
   const deactivateDialogRef = useRef<HTMLDialogElement>(null);
+  const deleteDialogRef = useRef<HTMLDialogElement>(null);
 
   const [form, setForm] = useState(EMPTY_FORM);
   const [deactivateTarget, setDeactivateTarget] = useState<EquipmentItem | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<EquipmentItem | null>(null);
+  const [deleteSubmitPending, setDeleteSubmitPending] = useState(false);
   const [equipmentDialogOpen, setEquipmentDialogOpen] = useState(false);
   const [deactivateDialogOpen, setDeactivateDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   useEffect(() => {
     const dialog = equipmentDialogRef.current;
@@ -174,6 +228,25 @@ export default function EquipmentPage() {
       dialog.close();
     }
   }, [deactivateDialogOpen]);
+
+  useEffect(() => {
+    const dialog = deleteDialogRef.current;
+    if (!dialog) return;
+
+    if (deleteDialogOpen && !dialog.open) {
+      dialog.showModal();
+    } else if (!deleteDialogOpen && dialog.open) {
+      dialog.close();
+    }
+  }, [deleteDialogOpen]);
+
+  useEffect(() => {
+    if (deleteDialogOpen && deleteSubmitPending && fetcher.state === "idle" && fetcher.data?.ok) {
+      setDeleteSubmitPending(false);
+      setDeleteDialogOpen(false);
+      setDeleteTarget(null);
+    }
+  }, [deleteDialogOpen, deleteSubmitPending, fetcher.state, fetcher.data]);
 
   function updateForm<K extends keyof typeof EMPTY_FORM>(key: K, value: (typeof EMPTY_FORM)[K]) {
     setForm((current) => ({ ...current, [key]: value }));
@@ -200,6 +273,12 @@ export default function EquipmentPage() {
     setDeactivateDialogOpen(true);
   }
 
+  function confirmDelete(item: EquipmentItem) {
+    setDeleteSubmitPending(false);
+    setDeleteTarget(item);
+    setDeleteDialogOpen(true);
+  }
+
   function closeEquipmentDialog() {
     setEquipmentDialogOpen(false);
     setForm(EMPTY_FORM);
@@ -208,6 +287,12 @@ export default function EquipmentPage() {
   function closeDeactivateDialog() {
     setDeactivateDialogOpen(false);
     setDeactivateTarget(null);
+  }
+
+  function closeDeleteDialog() {
+    setDeleteSubmitPending(false);
+    setDeleteDialogOpen(false);
+    setDeleteTarget(null);
   }
 
   const isSubmitting = fetcher.state !== "idle";
@@ -235,7 +320,7 @@ export default function EquipmentPage() {
       </div>
 
       <s-page>
-        {fetcher.data && !fetcher.data.ok && (
+        {fetcher.data && !fetcher.data.ok && !deleteDialogOpen && (
           <s-banner tone="critical">
             <s-text>{fetcher.data.message}</s-text>
           </s-banner>
@@ -306,6 +391,9 @@ export default function EquipmentPage() {
                             <s-button type="submit" variant="secondary" disabled={isSubmitting}>Reactivate</s-button>
                           </fetcher.Form>
                         )}
+                        <s-button tone="critical" variant="secondary" onClick={() => confirmDelete(item)}>
+                          Delete
+                        </s-button>
                       </div>
                     </s-table-cell>
                   </s-table-row>
@@ -495,6 +583,80 @@ export default function EquipmentPage() {
               }}
             >
               Deactivate
+            </s-button>
+          </div>
+        </div>
+      </dialog>
+
+      <dialog
+        ref={deleteDialogRef}
+        onClose={closeDeleteDialog}
+        style={{
+          border: "none",
+          borderRadius: "1rem",
+          padding: 0,
+          maxWidth: "32rem",
+          width: "calc(100% - 2rem)",
+        }}
+      >
+        <div style={{ padding: "1.5rem", display: "grid", gap: "1rem" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: "1rem", alignItems: "start" }}>
+            <div style={{ display: "grid", gap: "0.25rem" }}>
+              <strong>Delete equipment</strong>
+              <s-text color="subdued">Delete this equipment permanently when it is no longer referenced by templates or variants.</s-text>
+            </div>
+            <button
+              type="button"
+              aria-label="Close dialog"
+              onClick={closeDeleteDialog}
+              style={{
+                border: "none",
+                background: "transparent",
+                fontSize: "1.5rem",
+                lineHeight: 1,
+                cursor: "pointer",
+              }}
+            >
+              Ã—
+            </button>
+          </div>
+
+          {fetcher.data && !fetcher.data.ok && deleteDialogOpen ? (
+            <s-banner tone="critical">
+              <s-text>{fetcher.data.message}</s-text>
+            </s-banner>
+          ) : null}
+
+          <s-text>
+            {deleteTarget
+              ? `Delete ${deleteTarget.name} permanently? This cannot be undone.`
+              : "Delete this equipment permanently? This cannot be undone."}
+          </s-text>
+
+          {deleteTarget && deleteTarget.templateCount + deleteTarget.variantCount > 0 ? (
+            <s-banner tone="warning">
+              <s-text>
+                This equipment is still used in {deleteTarget.templateCount} template(s) and {deleteTarget.variantCount} variant config(s), so deletion is blocked.
+              </s-text>
+            </s-banner>
+          ) : null}
+
+          <div style={{ display: "flex", justifyContent: "flex-end", gap: "0.75rem", flexWrap: "wrap" }}>
+            <s-button variant="secondary" onClick={closeDeleteDialog}>Cancel</s-button>
+            <s-button
+              variant="primary"
+              tone="critical"
+              disabled={isSubmitting || (deleteTarget ? deleteTarget.templateCount + deleteTarget.variantCount > 0 : true)}
+              onClick={() => {
+                if (!deleteTarget) return;
+                const fd = new FormData();
+                fd.append("intent", "delete");
+                fd.append("id", deleteTarget.id);
+                setDeleteSubmitPending(true);
+                fetcher.submit(fd, { method: "post" });
+              }}
+            >
+              Delete
             </s-button>
           </div>
         </div>

--- a/app/routes/app.materials.tsx
+++ b/app/routes/app.materials.tsx
@@ -1,9 +1,14 @@
 import { useEffect, useRef, useState } from "react";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { useFetcher, useLoaderData, useRouteError } from "@remix-run/react";
+import { z } from "zod";
 import { prisma } from "../db.server";
 import { authenticateAdminRequest } from "../utils/admin-auth.server";
 import { useAppLocalization } from "../utils/use-app-localization";
+
+const materialIdSchema = z.object({
+  id: z.string().trim().cuid("Material id is invalid."),
+});
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticateAdminRequest(request);
@@ -119,7 +124,11 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   }
 
   if (intent === "deactivate" || intent === "reactivate") {
-    const id = formData.get("id")?.toString() ?? "";
+    const parsed = materialIdSchema.safeParse({ id: formData.get("id")?.toString() ?? "" });
+    if (!parsed.success) {
+      return Response.json({ ok: false, message: parsed.error.issues[0]?.message ?? "Invalid material." }, { status: 400 });
+    }
+    const id = parsed.data.id;
     const status = intent === "deactivate" ? "inactive" : "active";
     await prisma.materialLibraryItem.update({ where: { id, shopId }, data: { status } });
     await prisma.auditLog.create({
@@ -135,6 +144,47 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       ok: true,
       message: intent === "deactivate" ? "Material deactivated." : "Material reactivated.",
     });
+  }
+
+  if (intent === "delete") {
+    const parsed = materialIdSchema.safeParse({ id: formData.get("id")?.toString() ?? "" });
+    if (!parsed.success) {
+      return Response.json({ ok: false, message: parsed.error.issues[0]?.message ?? "Invalid material." }, { status: 400 });
+    }
+
+    const material = await prisma.materialLibraryItem.findFirst({
+      where: { id: parsed.data.id, shopId },
+      include: {
+        _count: { select: { templateLines: true, variantLines: true } },
+      },
+    });
+
+    if (!material) {
+      return Response.json({ ok: false, message: "Material not found." }, { status: 404 });
+    }
+
+    if (material._count.templateLines > 0 || material._count.variantLines > 0) {
+      return Response.json(
+        {
+          ok: false,
+          message: `This material is still used in ${material._count.templateLines} template(s) and ${material._count.variantLines} variant config(s). Remove those references before deleting it.`,
+        },
+        { status: 400 },
+      );
+    }
+
+    await prisma.materialLibraryItem.delete({ where: { id: material.id, shopId } });
+    await prisma.auditLog.create({
+      data: {
+        shopId,
+        entity: "MaterialLibraryItem",
+        entityId: material.id,
+        action: "MATERIAL_DELETED",
+        actor: "merchant",
+      },
+    });
+
+    return Response.json({ ok: true, message: "Material deleted." });
   }
 
   return Response.json({ ok: false, message: "Unknown action." }, { status: 400 });
@@ -174,11 +224,15 @@ export default function MaterialsPage() {
   const { formatMoney, getCurrencySymbol } = useAppLocalization();
   const materialDialogRef = useRef<HTMLDialogElement>(null);
   const deactivateDialogRef = useRef<HTMLDialogElement>(null);
+  const deleteDialogRef = useRef<HTMLDialogElement>(null);
 
   const [form, setForm] = useState(EMPTY_FORM);
   const [deactivateTarget, setDeactivateTarget] = useState<Material | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Material | null>(null);
+  const [deleteSubmitPending, setDeleteSubmitPending] = useState(false);
   const [materialDialogOpen, setMaterialDialogOpen] = useState(false);
   const [deactivateDialogOpen, setDeactivateDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   useEffect(() => {
     const dialog = materialDialogRef.current;
@@ -201,6 +255,25 @@ export default function MaterialsPage() {
       dialog.close();
     }
   }, [deactivateDialogOpen]);
+
+  useEffect(() => {
+    const dialog = deleteDialogRef.current;
+    if (!dialog) return;
+
+    if (deleteDialogOpen && !dialog.open) {
+      dialog.showModal();
+    } else if (!deleteDialogOpen && dialog.open) {
+      dialog.close();
+    }
+  }, [deleteDialogOpen]);
+
+  useEffect(() => {
+    if (deleteDialogOpen && deleteSubmitPending && fetcher.state === "idle" && fetcher.data?.ok) {
+      setDeleteSubmitPending(false);
+      setDeleteDialogOpen(false);
+      setDeleteTarget(null);
+    }
+  }, [deleteDialogOpen, deleteSubmitPending, fetcher.state, fetcher.data]);
 
   function openCreate() {
     setForm(EMPTY_FORM);
@@ -227,6 +300,12 @@ export default function MaterialsPage() {
     setDeactivateDialogOpen(true);
   }
 
+  function confirmDelete(material: Material) {
+    setDeleteSubmitPending(false);
+    setDeleteTarget(material);
+    setDeleteDialogOpen(true);
+  }
+
   function closeMaterialDialog() {
     setMaterialDialogOpen(false);
     setForm(EMPTY_FORM);
@@ -235,6 +314,12 @@ export default function MaterialsPage() {
   function closeDeactivateDialog() {
     setDeactivateDialogOpen(false);
     setDeactivateTarget(null);
+  }
+
+  function closeDeleteDialog() {
+    setDeleteSubmitPending(false);
+    setDeleteDialogOpen(false);
+    setDeleteTarget(null);
   }
 
   function updateForm<K extends keyof typeof EMPTY_FORM>(key: K, value: (typeof EMPTY_FORM)[K]) {
@@ -276,7 +361,7 @@ export default function MaterialsPage() {
       </div>
 
       <s-page>
-        {fetcher.data && !fetcher.data.ok && (
+        {fetcher.data && !fetcher.data.ok && !deleteDialogOpen && (
           <s-banner tone="critical">
             <s-text>{fetcher.data.message}</s-text>
           </s-banner>
@@ -356,6 +441,9 @@ export default function MaterialsPage() {
                             <s-button type="submit" variant="secondary" disabled={isSubmitting}>Reactivate</s-button>
                           </fetcher.Form>
                         )}
+                        <s-button tone="critical" variant="secondary" onClick={() => confirmDelete(material)}>
+                          Delete
+                        </s-button>
                       </div>
                     </s-table-cell>
                   </s-table-row>
@@ -612,6 +700,80 @@ export default function MaterialsPage() {
               }}
             >
               Deactivate
+            </s-button>
+          </div>
+        </div>
+      </dialog>
+
+      <dialog
+        ref={deleteDialogRef}
+        onClose={closeDeleteDialog}
+        style={{
+          border: "none",
+          borderRadius: "1rem",
+          padding: 0,
+          maxWidth: "32rem",
+          width: "calc(100% - 2rem)",
+        }}
+      >
+        <div style={{ padding: "1.5rem", display: "grid", gap: "1rem" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: "1rem", alignItems: "start" }}>
+            <div style={{ display: "grid", gap: "0.25rem" }}>
+              <strong>Delete material</strong>
+              <s-text color="subdued">Delete this material permanently when it is no longer referenced by templates or variants.</s-text>
+            </div>
+            <button
+              type="button"
+              aria-label="Close dialog"
+              onClick={closeDeleteDialog}
+              style={{
+                border: "none",
+                background: "transparent",
+                fontSize: "1.5rem",
+                lineHeight: 1,
+                cursor: "pointer",
+              }}
+            >
+              Ã—
+            </button>
+          </div>
+
+          {fetcher.data && !fetcher.data.ok && deleteDialogOpen ? (
+            <s-banner tone="critical">
+              <s-text>{fetcher.data.message}</s-text>
+            </s-banner>
+          ) : null}
+
+          <s-text>
+            {deleteTarget
+              ? `Delete ${deleteTarget.name} permanently? This cannot be undone.`
+              : "Delete this material permanently? This cannot be undone."}
+          </s-text>
+
+          {deleteTarget && deleteTarget.templateCount + deleteTarget.variantCount > 0 ? (
+            <s-banner tone="warning">
+              <s-text>
+                This material is still used in {deleteTarget.templateCount} template(s) and {deleteTarget.variantCount} variant config(s), so deletion is blocked.
+              </s-text>
+            </s-banner>
+          ) : null}
+
+          <div style={{ display: "flex", justifyContent: "flex-end", gap: "0.75rem", flexWrap: "wrap" }}>
+            <s-button variant="secondary" onClick={closeDeleteDialog}>Cancel</s-button>
+            <s-button
+              variant="primary"
+              tone="critical"
+              disabled={isSubmitting || (deleteTarget ? deleteTarget.templateCount + deleteTarget.variantCount > 0 : true)}
+              onClick={() => {
+                if (!deleteTarget) return;
+                const fd = new FormData();
+                fd.append("intent", "delete");
+                fd.append("id", deleteTarget.id);
+                setDeleteSubmitPending(true);
+                fetcher.submit(fd, { method: "post" });
+              }}
+            >
+              Delete
             </s-button>
           </div>
         </div>

--- a/app/routes/app.templates._index.tsx
+++ b/app/routes/app.templates._index.tsx
@@ -1,8 +1,13 @@
 import { useEffect, useRef, useState } from "react";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { Link, useFetcher, useLoaderData, useRouteError } from "@remix-run/react";
+import { z } from "zod";
 import { prisma } from "../db.server";
 import { authenticateAdminRequest } from "../utils/admin-auth.server";
+
+const templateIdSchema = z.object({
+  id: z.string().trim().cuid("Template id is invalid."),
+});
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticateAdminRequest(request);
@@ -64,7 +69,11 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   }
 
   if (intent === "deactivate" || intent === "reactivate") {
-    const id = formData.get("id")?.toString() ?? "";
+    const parsed = templateIdSchema.safeParse({ id: formData.get("id")?.toString() ?? "" });
+    if (!parsed.success) {
+      return Response.json({ ok: false, message: parsed.error.issues[0]?.message ?? "Invalid template." }, { status: 400 });
+    }
+    const id = parsed.data.id;
     const status = intent === "deactivate" ? "inactive" : "active";
 
     await prisma.costTemplate.update({ where: { id, shopId }, data: { status } });
@@ -82,6 +91,49 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       ok: true,
       message: intent === "deactivate" ? "Template deactivated." : "Template reactivated.",
     });
+  }
+
+  if (intent === "delete") {
+    const parsed = templateIdSchema.safeParse({ id: formData.get("id")?.toString() ?? "" });
+    if (!parsed.success) {
+      return Response.json({ ok: false, message: parsed.error.issues[0]?.message ?? "Invalid template." }, { status: 400 });
+    }
+
+    const template = await prisma.costTemplate.findFirst({
+      where: { id: parsed.data.id, shopId },
+      include: {
+        _count: {
+          select: { variantConfigs: true, materialLines: true, equipmentLines: true },
+        },
+      },
+    });
+
+    if (!template) {
+      return Response.json({ ok: false, message: "Template not found." }, { status: 404 });
+    }
+
+    if (template._count.variantConfigs > 0) {
+      return Response.json(
+        {
+          ok: false,
+          message: `This template is still assigned to ${template._count.variantConfigs} variant(s). Remove those assignments before deleting it.`,
+        },
+        { status: 400 },
+      );
+    }
+
+    await prisma.costTemplate.delete({ where: { id: template.id, shopId } });
+    await prisma.auditLog.create({
+      data: {
+        shopId,
+        entity: "CostTemplate",
+        entityId: template.id,
+        action: "TEMPLATE_DELETED",
+        actor: "merchant",
+      },
+    });
+
+    return Response.json({ ok: true, message: "Template deleted." });
   }
 
   return Response.json({ ok: false, message: "Unknown action." }, { status: 400 });
@@ -102,12 +154,16 @@ export default function TemplatesPage() {
   const fetcher = useFetcher<{ ok: boolean; message: string; id?: string }>();
   const createDialogRef = useRef<HTMLDialogElement>(null);
   const deactivateDialogRef = useRef<HTMLDialogElement>(null);
+  const deleteDialogRef = useRef<HTMLDialogElement>(null);
 
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [deactivateDialogOpen, setDeactivateDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [newName, setNewName] = useState("");
   const [newDesc, setNewDesc] = useState("");
   const [deactivateTarget, setDeactivateTarget] = useState<Template | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Template | null>(null);
+  const [deleteSubmitPending, setDeleteSubmitPending] = useState(false);
 
   useEffect(() => {
     const dialog = createDialogRef.current;
@@ -131,6 +187,25 @@ export default function TemplatesPage() {
     }
   }, [deactivateDialogOpen]);
 
+  useEffect(() => {
+    const dialog = deleteDialogRef.current;
+    if (!dialog) return;
+
+    if (deleteDialogOpen && !dialog.open) {
+      dialog.showModal();
+    } else if (!deleteDialogOpen && dialog.open) {
+      dialog.close();
+    }
+  }, [deleteDialogOpen]);
+
+  useEffect(() => {
+    if (deleteDialogOpen && deleteSubmitPending && fetcher.state === "idle" && fetcher.data?.ok) {
+      setDeleteSubmitPending(false);
+      setDeleteDialogOpen(false);
+      setDeleteTarget(null);
+    }
+  }, [deleteDialogOpen, deleteSubmitPending, fetcher.state, fetcher.data]);
+
   function openCreateDialog() {
     setNewName("");
     setNewDesc("");
@@ -151,6 +226,18 @@ export default function TemplatesPage() {
   function closeDeactivateDialog() {
     setDeactivateDialogOpen(false);
     setDeactivateTarget(null);
+  }
+
+  function openDeleteDialog(template: Template) {
+    setDeleteSubmitPending(false);
+    setDeleteTarget(template);
+    setDeleteDialogOpen(true);
+  }
+
+  function closeDeleteDialog() {
+    setDeleteSubmitPending(false);
+    setDeleteDialogOpen(false);
+    setDeleteTarget(null);
   }
 
   const isSubmitting = fetcher.state !== "idle";
@@ -178,7 +265,7 @@ export default function TemplatesPage() {
       </div>
 
       <s-page>
-        {fetcher.data && !fetcher.data.ok && (
+        {fetcher.data && !fetcher.data.ok && !deleteDialogOpen && (
           <s-banner tone="critical">
             <s-text>{fetcher.data.message}</s-text>
           </s-banner>
@@ -255,6 +342,9 @@ export default function TemplatesPage() {
                             <s-button type="submit" variant="secondary" disabled={isSubmitting}>Reactivate</s-button>
                           </fetcher.Form>
                         )}
+                        <s-button tone="critical" variant="secondary" onClick={() => openDeleteDialog(template)}>
+                          Delete
+                        </s-button>
                       </div>
                     </s-table-cell>
                   </s-table-row>
@@ -404,6 +494,80 @@ export default function TemplatesPage() {
               }}
             >
               Deactivate
+            </s-button>
+          </div>
+        </div>
+      </dialog>
+
+      <dialog
+        ref={deleteDialogRef}
+        onClose={closeDeleteDialog}
+        style={{
+          border: "none",
+          borderRadius: "1rem",
+          padding: 0,
+          maxWidth: "32rem",
+          width: "calc(100% - 2rem)",
+        }}
+      >
+        <div style={{ padding: "1.5rem", display: "grid", gap: "1rem" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: "1rem", alignItems: "start" }}>
+            <div style={{ display: "grid", gap: "0.25rem" }}>
+              <strong>Delete template</strong>
+              <s-text color="subdued">Delete this template permanently when it is no longer assigned to variants.</s-text>
+            </div>
+            <button
+              type="button"
+              aria-label="Close dialog"
+              onClick={closeDeleteDialog}
+              style={{
+                border: "none",
+                background: "transparent",
+                fontSize: "1.5rem",
+                lineHeight: 1,
+                cursor: "pointer",
+              }}
+            >
+              Ã—
+            </button>
+          </div>
+
+          {fetcher.data && !fetcher.data.ok && deleteDialogOpen ? (
+            <s-banner tone="critical">
+              <s-text>{fetcher.data.message}</s-text>
+            </s-banner>
+          ) : null}
+
+          <s-text>
+            {deleteTarget
+              ? `Delete ${deleteTarget.name} permanently? Its ${deleteTarget.materialLineCount + deleteTarget.equipmentLineCount} line(s) will be removed with it.`
+              : "Delete this template permanently?"}
+          </s-text>
+
+          {deleteTarget && deleteTarget.variantCount > 0 ? (
+            <s-banner tone="warning">
+              <s-text>
+                This template is still assigned to {deleteTarget.variantCount} variant(s), so deletion is blocked.
+              </s-text>
+            </s-banner>
+          ) : null}
+
+          <div style={{ display: "flex", justifyContent: "flex-end", gap: "0.75rem", flexWrap: "wrap" }}>
+            <s-button variant="secondary" onClick={closeDeleteDialog}>Cancel</s-button>
+            <s-button
+              variant="primary"
+              tone="critical"
+              disabled={isSubmitting || (deleteTarget?.variantCount ?? 0) > 0}
+              onClick={() => {
+                if (!deleteTarget) return;
+                const fd = new FormData();
+                fd.append("intent", "delete");
+                fd.append("id", deleteTarget.id);
+                setDeleteSubmitPending(true);
+                fetcher.submit(fd, { method: "post" });
+              }}
+            >
+              Delete
             </s-button>
           </div>
         </div>

--- a/app/routes/ui-fixtures.causes-bootstrap.tsx
+++ b/app/routes/ui-fixtures.causes-bootstrap.tsx
@@ -4,6 +4,7 @@ import { prisma } from "../db.server";
 
 const shopId = "playwright-test-shop.myshopify.com";
 const shopifyDomain = "playwright-test-shop.myshopify.com";
+const productShopifyId = "gid://shopify/Product/900000000201";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const url = new URL(request.url);
@@ -25,6 +26,50 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       name: {
         startsWith: "Playwright Cause UI",
       },
+    },
+  });
+
+  const syncedAt = new Date();
+  const product = await prisma.product.upsert({
+    where: {
+      shopId_shopifyId: {
+        shopId,
+        shopifyId: productShopifyId,
+      },
+    },
+    update: {
+      title: "Playwright Cause Product",
+      handle: "playwright-cause-product",
+      status: "active",
+      syncedAt,
+    },
+    create: {
+      shopId,
+      shopifyId: productShopifyId,
+      title: "Playwright Cause Product",
+      handle: "playwright-cause-product",
+      status: "active",
+      syncedAt,
+    },
+  });
+
+  const assignedCause = await prisma.cause.create({
+    data: {
+      shopId,
+      name: "Playwright Cause UI Assigned",
+      legalName: "Playwright Cause UI Assigned Foundation",
+      status: "active",
+      is501c3: true,
+    },
+  });
+
+  await prisma.productCauseAssignment.create({
+    data: {
+      shopId,
+      shopifyProductId: product.shopifyId,
+      causeId: assignedCause.id,
+      productId: product.id,
+      percentage: "25.00",
     },
   });
 

--- a/app/routes/ui-fixtures.library-pages-bootstrap.tsx
+++ b/app/routes/ui-fixtures.library-pages-bootstrap.tsx
@@ -4,6 +4,8 @@ import { prisma } from "../db.server";
 
 const shopId = "playwright-test-shop.myshopify.com";
 const shopifyDomain = "playwright-test-shop.myshopify.com";
+const productShopifyId = "gid://shopify/Product/900000000101";
+const variantShopifyId = "gid://shopify/ProductVariant/900000000101";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const url = new URL(request.url);
@@ -13,6 +15,68 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     where: { shopId },
     update: { shopifyDomain, currency: "USD" },
     create: { shopId, shopifyDomain, currency: "USD" },
+  });
+
+  const syncedAt = new Date();
+  const product = await prisma.product.upsert({
+    where: {
+      shopId_shopifyId: {
+        shopId,
+        shopifyId: productShopifyId,
+      },
+    },
+    update: {
+      title: "Playwright Library Product",
+      handle: "playwright-library-product",
+      status: "active",
+      syncedAt,
+    },
+    create: {
+      shopId,
+      shopifyId: productShopifyId,
+      title: "Playwright Library Product",
+      handle: "playwright-library-product",
+      status: "active",
+      syncedAt,
+    },
+  });
+
+  const variant = await prisma.variant.upsert({
+    where: {
+      shopId_shopifyId: {
+        shopId,
+        shopifyId: variantShopifyId,
+      },
+    },
+    update: {
+      productId: product.id,
+      title: "Playwright Library Variant",
+      sku: "PW-LIB-001",
+      price: "24.99",
+      syncedAt,
+    },
+    create: {
+      shopId,
+      shopifyId: variantShopifyId,
+      productId: product.id,
+      title: "Playwright Library Variant",
+      sku: "PW-LIB-001",
+      price: "24.99",
+      syncedAt,
+    },
+  });
+
+  await prisma.variantCostConfig.deleteMany({
+    where: { shopId, variantId: variant.id },
+  });
+
+  await prisma.costTemplate.deleteMany({
+    where: {
+      shopId,
+      name: {
+        startsWith: "Playwright Template UI",
+      },
+    },
   });
 
   await prisma.materialLibraryItem.deleteMany({
@@ -33,12 +97,72 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     },
   });
 
-  await prisma.costTemplate.deleteMany({
-    where: {
+  const usedMaterial = await prisma.materialLibraryItem.create({
+    data: {
       shopId,
-      name: {
-        startsWith: "Playwright Template UI",
+      name: "Playwright Material UI Used",
+      type: "production",
+      costingModel: "yield",
+      purchasePrice: "12.00",
+      purchaseQty: "1.00",
+      perUnitCost: "12.000000",
+      totalUsesPerUnit: null,
+      status: "active",
+    },
+  });
+
+  await prisma.materialLibraryItem.create({
+    data: {
+      shopId,
+      name: "Playwright Material UI Delete",
+      type: "production",
+      costingModel: "yield",
+      purchasePrice: "10.00",
+      purchaseQty: "1.00",
+      perUnitCost: "10.000000",
+      totalUsesPerUnit: null,
+      status: "active",
+    },
+  });
+
+  const usedEquipment = await prisma.equipmentLibraryItem.create({
+    data: {
+      shopId,
+      name: "Playwright Equipment UI Used",
+      hourlyRate: "30.00",
+      perUseCost: null,
+      status: "active",
+    },
+  });
+
+  const usedTemplate = await prisma.costTemplate.create({
+    data: {
+      shopId,
+      name: "Playwright Template UI Used",
+      description: "Used by a fixture variant config",
+      status: "active",
+      materialLines: {
+        create: {
+          materialId: usedMaterial.id,
+          quantity: "1.00",
+          yield: "12.00",
+        },
       },
+      equipmentLines: {
+        create: {
+          equipmentId: usedEquipment.id,
+          minutes: "5.00",
+        },
+      },
+    },
+  });
+
+  await prisma.variantCostConfig.create({
+    data: {
+      shopId,
+      variantId: variant.id,
+      templateId: usedTemplate.id,
+      lineItemCount: 0,
     },
   });
 

--- a/app/services/causeMetaobjectService.server.ts
+++ b/app/services/causeMetaobjectService.server.ts
@@ -72,6 +72,19 @@ const METAOBJECT_UPDATE_MUTATION = `#graphql
   }
 `;
 
+const METAOBJECT_DELETE_MUTATION = `#graphql
+  mutation DeleteCauseMetaobject($id: ID!) {
+    metaobjectDelete(id: $id) {
+      deletedId
+      userErrors {
+        field
+        message
+        code
+      }
+    }
+  }
+`;
+
 type GraphqlUserError = {
   field?: string[] | null;
   message: string;
@@ -224,6 +237,32 @@ export async function updateCauseMetaobject(
 
   const payload = json.data?.metaobjectUpdate;
   if (!payload?.metaobject) {
+    throw new Error(getUserErrorMessage(payload?.userErrors ?? []));
+  }
+  if ((payload.userErrors ?? []).length > 0) {
+    throw new Error(getUserErrorMessage(payload.userErrors));
+  }
+}
+
+export async function deleteCauseMetaobject(
+  admin: AdminContext,
+  metaobjectId: string,
+): Promise<void> {
+  const response = await admin.graphql(METAOBJECT_DELETE_MUTATION, {
+    variables: { id: metaobjectId },
+  });
+
+  const json = await parseGraphqlResponse<{
+    data?: {
+      metaobjectDelete?: {
+        deletedId?: string | null;
+        userErrors: GraphqlUserError[];
+      };
+    };
+  }>(response);
+
+  const payload = json.data?.metaobjectDelete;
+  if (!payload?.deletedId) {
     throw new Error(getUserErrorMessage(payload?.userErrors ?? []));
   }
   if ((payload.userErrors ?? []).length > 0) {

--- a/tests/ui/causes-workflow.spec.ts
+++ b/tests/ui/causes-workflow.spec.ts
@@ -62,3 +62,30 @@ test("causes show inline URL validation errors in the modal", async ({ page, req
   await expect(causeDialog.locator("#cause-name")).toHaveValue("Playwright Invalid Cause");
   await expect(page.locator("s-table-row").filter({ has: page.getByText("Playwright Invalid Cause") })).toHaveCount(0);
 });
+
+test("unused causes can be deleted and assigned causes show a blocked delete explanation", async ({ page, request }) => {
+  const bootstrapResponse = await request.get("/ui-fixtures/causes-bootstrap");
+  expect(bootstrapResponse.ok()).toBeTruthy();
+
+  const bootstrap = await bootstrapResponse.json();
+  await page.goto(bootstrap.causesUrl);
+
+  await page.getByText("New cause", { exact: true }).nth(1).click();
+  const causeDialog = page.getByRole("dialog").filter({ hasText: "New cause" });
+  await causeDialog.locator("#cause-name").fill("Playwright Cause UI Delete");
+  await causeDialog.locator("#cause-donationLink").fill("https://example.org/delete");
+  await causeDialog.getByRole("button", { name: "Create" }).click();
+
+  const deletableRow = page.locator("s-table-row").filter({ has: page.getByText("Playwright Cause UI Delete") });
+  await expect(deletableRow).toBeVisible();
+  await deletableRow.getByRole("button", { name: "Delete" }).click();
+  const deleteDialog = page.getByRole("dialog").filter({ hasText: "Delete cause" });
+  await deleteDialog.getByRole("button", { name: "Delete" }).click();
+  await expect(page.getByText("Cause deleted.")).toBeVisible();
+  await expect(deletableRow).toHaveCount(0);
+
+  const usedRow = page.locator("s-table-row").filter({ has: page.getByText("Playwright Cause UI Assigned") });
+  await usedRow.getByRole("button", { name: "Delete" }).click();
+  await expect(deleteDialog.getByText("This Cause is still assigned to 1 product(s), so deletion is blocked.")).toBeVisible();
+  await expect(deleteDialog.getByRole("button", { name: "Delete" })).toBeDisabled();
+});

--- a/tests/ui/equipment-workflow.spec.ts
+++ b/tests/ui/equipment-workflow.spec.ts
@@ -34,3 +34,31 @@ test("equipment can be created, deactivated, and reactivated on the real route",
   await expect(page.getByText("Equipment reactivated.")).toBeVisible();
   await expect(equipmentRow.getByText("Active")).toBeVisible();
 });
+
+test("unused equipment can be deleted and used equipment show a blocked delete explanation", async ({ page, request }) => {
+  const bootstrapResponse = await request.get("/ui-fixtures/library-pages-bootstrap");
+  expect(bootstrapResponse.ok()).toBeTruthy();
+
+  const bootstrap = await bootstrapResponse.json();
+  await page.goto(bootstrap.equipmentUrl);
+
+  await page.locator("ui-title-bar button").filter({ hasText: "New equipment" }).click();
+  const equipmentDialog = page.getByRole("dialog").filter({ hasText: "New equipment" });
+  await equipmentDialog.getByLabel("Name").fill("Playwright Equipment UI Delete");
+  await equipmentDialog.getByLabel(/Hourly rate/).fill("45.00");
+  await equipmentDialog.getByRole("button", { name: "Create" }).click();
+  await expect(page.getByText("Equipment created.")).toBeVisible();
+
+  const deletableRow = page.locator("s-table-row").filter({ has: page.getByText("Playwright Equipment UI Delete") });
+  await expect(deletableRow).toBeVisible();
+  await deletableRow.getByRole("button", { name: "Delete" }).click();
+  const deleteDialog = page.getByRole("dialog").filter({ hasText: "Delete equipment" });
+  await deleteDialog.getByRole("button", { name: "Delete" }).click();
+  await expect(page.getByText("Equipment deleted.")).toBeVisible();
+  await expect(deletableRow).toHaveCount(0);
+
+  const usedRow = page.locator("s-table-row").filter({ has: page.getByText("Playwright Equipment UI Used") });
+  await usedRow.getByRole("button", { name: "Delete" }).click();
+  await expect(deleteDialog.getByText("This equipment is still used in 1 template(s) and 0 variant config(s), so deletion is blocked.")).toBeVisible();
+  await expect(deleteDialog.getByRole("button", { name: "Delete" })).toBeDisabled();
+});

--- a/tests/ui/materials-workflow.spec.ts
+++ b/tests/ui/materials-workflow.spec.ts
@@ -25,3 +25,26 @@ test("materials can be deactivated and reactivated on the real route", async ({ 
   await expect(page.getByText("Material reactivated.")).toBeVisible();
   await expect(materialRow.getByText("Active")).toBeVisible();
 });
+
+test("unused materials can be deleted and used materials show a blocked delete explanation", async ({ page, request }) => {
+  const bootstrapResponse = await request.get("/ui-fixtures/library-pages-bootstrap");
+  expect(bootstrapResponse.ok()).toBeTruthy();
+
+  const bootstrap = await bootstrapResponse.json();
+  await page.goto(bootstrap.materialsUrl);
+
+  const deletableRow = page.locator("s-table-row").filter({ has: page.getByText("Playwright Material UI Delete") });
+  await expect(deletableRow).toBeVisible();
+  await deletableRow.getByRole("button", { name: "Delete" }).click();
+  const deleteDialog = page.getByRole("dialog").filter({ hasText: "Delete material" });
+  await expect(deleteDialog).toBeVisible();
+  await deleteDialog.getByRole("button", { name: "Delete" }).click();
+  await expect(page.getByText("Material deleted.")).toBeVisible();
+  await expect(deletableRow).toHaveCount(0);
+
+  const usedRow = page.locator("s-table-row").filter({ has: page.getByText("Playwright Material UI Used") });
+  await usedRow.getByRole("button", { name: "Delete" }).click();
+  await expect(deleteDialog).toBeVisible();
+  await expect(deleteDialog.getByText("This material is still used in 1 template(s) and 0 variant config(s), so deletion is blocked.")).toBeVisible();
+  await expect(deleteDialog.getByRole("button", { name: "Delete" })).toBeDisabled();
+});

--- a/tests/ui/templates-index-workflow.spec.ts
+++ b/tests/ui/templates-index-workflow.spec.ts
@@ -34,3 +34,31 @@ test("cost templates can be created, deactivated, and reactivated on the real ro
   await expect(page.getByText("Template reactivated.")).toBeVisible();
   await expect(templateRow.getByText("Active")).toBeVisible();
 });
+
+test("unused templates can be deleted and assigned templates show a blocked delete explanation", async ({ page, request }) => {
+  const bootstrapResponse = await request.get("/ui-fixtures/library-pages-bootstrap");
+  expect(bootstrapResponse.ok()).toBeTruthy();
+
+  const bootstrap = await bootstrapResponse.json();
+  await page.goto(bootstrap.templatesUrl);
+
+  await page.locator("ui-title-bar button").filter({ hasText: "New template" }).click();
+  const templateDialog = page.getByRole("dialog").filter({ hasText: "New template" });
+  await templateDialog.getByLabel("Name").fill("Playwright Template UI Delete");
+  await templateDialog.locator("#template-description").fill("Delete me");
+  await templateDialog.getByRole("button", { name: "Create" }).click();
+  await expect(page.getByText("Template created.")).toBeVisible();
+
+  const deletableRow = page.locator("s-table-row").filter({ has: page.getByText("Playwright Template UI Delete") });
+  await expect(deletableRow).toBeVisible();
+  await deletableRow.getByRole("button", { name: "Delete" }).click();
+  const deleteDialog = page.getByRole("dialog").filter({ hasText: "Delete template" });
+  await deleteDialog.getByRole("button", { name: "Delete" }).click();
+  await expect(page.getByText("Template deleted.")).toBeVisible();
+  await expect(deletableRow).toHaveCount(0);
+
+  const usedRow = page.locator("s-table-row").filter({ has: page.getByText("Playwright Template UI Used") });
+  await usedRow.getByRole("button", { name: "Delete" }).click();
+  await expect(deleteDialog.getByText("This template is still assigned to 1 variant(s), so deletion is blocked.")).toBeVisible();
+  await expect(deleteDialog.getByRole("button", { name: "Delete" })).toBeDisabled();
+});


### PR DESCRIPTION
## Summary
- allow Materials, Equipment, Cost Templates, and Causes to be deleted only when unused
- add inline delete-block explanations and confirmation dialogs on the relevant library pages
- add Playwright coverage for successful deletes and blocked deletes, plus Cause metaobject cleanup support

## Validation
- `npx tsc --noEmit`
- `npm run lint`
- `npm run test:ui -- --grep "unused materials can be deleted|unused equipment can be deleted|unused templates can be deleted|unused causes can be deleted"`