### PR TITLE
Centralize integer validation for line counts

### DIFF
--- a/app/routes/app.templates.$templateId.tsx
+++ b/app/routes/app.templates.$templateId.tsx
@@ -22,6 +22,11 @@ import { z } from "zod";
 import { AppSaveBar } from "../components/AppSaveBar";
 import { prisma } from "../db.server";
 import { authenticateAdminRequest } from "../utils/admin-auth.server";
+import {
+  parseOptionalNonNegativeNumber,
+  parseOptionalNonNegativeWholeNumber,
+  parseRequiredNonNegativeWholeNumber,
+} from "../utils/number-parsing";
 import { useAppLocalization } from "../utils/use-app-localization";
 import { useUnsavedChangesGuard } from "../utils/use-unsaved-changes-guard";
 import {
@@ -51,32 +56,6 @@ const templateDraftSchema = z.object({
     uses: z.string().nullable(),
   })),
 });
-
-function parseOptionalNumber(value: string | null | undefined, field: string) {
-  if (!value || !value.trim()) return null;
-  const parsed = Number(value);
-  if (Number.isNaN(parsed) || parsed < 0) {
-    throw new Response(`${field} must be a non-negative number.`, { status: 400 });
-  }
-  return parsed;
-}
-
-function parseOptionalWholeNumber(value: string | null | undefined, field: string) {
-  if (!value || !value.trim()) return null;
-  const parsed = Number(value);
-  if (Number.isNaN(parsed) || parsed < 0 || !Number.isInteger(parsed)) {
-    throw new Response(`${field} must be a non-negative whole number.`, { status: 400 });
-  }
-  return parsed;
-}
-
-function parseRequiredWholeNumber(value: string, field: string) {
-  const parsed = Number(value);
-  if (Number.isNaN(parsed) || parsed < 0 || !Number.isInteger(parsed)) {
-    throw new Response(`${field} must be a non-negative whole number.`, { status: 400 });
-  }
-  return parsed;
-}
 
 function serializeTemplate(template: {
   id: string;
@@ -340,9 +319,9 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
 
     for (const line of draft.materialLines) {
       const data = {
-        quantity: parseRequiredWholeNumber(line.quantity, "Material quantity"),
-        yield: parseOptionalWholeNumber(line.yield, "Material yield"),
-        usesPerVariant: parseOptionalWholeNumber(line.usesPerVariant, "Material uses per variant"),
+        quantity: parseRequiredNonNegativeWholeNumber(line.quantity, "Material quantity"),
+        yield: parseOptionalNonNegativeWholeNumber(line.yield, "Material yield"),
+        usesPerVariant: parseOptionalNonNegativeWholeNumber(line.usesPerVariant, "Material uses per variant"),
       };
 
       if (existingMaterialLines.has(line.id)) {
@@ -363,8 +342,8 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
 
     for (const line of draft.equipmentLines) {
       const data = {
-        minutes: parseOptionalNumber(line.minutes, "Equipment minutes"),
-        uses: parseOptionalWholeNumber(line.uses, "Equipment uses"),
+        minutes: parseOptionalNonNegativeNumber(line.minutes, "Equipment minutes"),
+        uses: parseOptionalNonNegativeWholeNumber(line.uses, "Equipment uses"),
       };
 
       if (existingEquipmentLines.has(line.id)) {

--- a/app/routes/app.variants.$variantId.tsx
+++ b/app/routes/app.variants.$variantId.tsx
@@ -22,6 +22,11 @@ import { prisma } from "../db.server";
 import { resolveCosts } from "../services/costEngine.server";
 import { authenticateAdminRequest } from "../utils/admin-auth.server";
 import { normalizeFixedDecimalInput } from "../utils/input-formatting";
+import {
+  parseOptionalNonNegativeNumber,
+  parseOptionalNonNegativeWholeNumber,
+  parseOptionalPercent,
+} from "../utils/number-parsing";
 import { useAppLocalization } from "../utils/use-app-localization";
 import { useUnsavedChangesGuard } from "../utils/use-unsaved-changes-guard";
 import { resolveEffectiveTemplateSelection } from "../utils/effective-template-selection";
@@ -174,33 +179,6 @@ const variantDraftSchema = z.object({
     uses: z.string().nullable(),
   })),
 });
-
-function parseNullableNumber(value: string | null | undefined, field: string) {
-  if (!value || !value.trim()) return null;
-  const parsed = Number(value);
-  if (Number.isNaN(parsed) || parsed < 0) {
-    throw new Response(`${field} must be a non-negative number.`, { status: 400 });
-  }
-  return parsed;
-}
-
-function parseNullableWholeNumber(value: string | null | undefined, field: string) {
-  if (!value || !value.trim()) return null;
-  const parsed = Number(value);
-  if (Number.isNaN(parsed) || parsed < 0 || !Number.isInteger(parsed)) {
-    throw new Response(`${field} must be a non-negative whole number.`, { status: 400 });
-  }
-  return parsed;
-}
-
-function parseOptionalPercent(value: string | null | undefined) {
-  if (!value || !value.trim()) return null;
-  const parsed = Number(value);
-  if (Number.isNaN(parsed) || parsed < 0 || parsed > 100) {
-    throw new Response("Mistake buffer must be between 0 and 100.", { status: 400 });
-  }
-  return parsed / 100;
-}
 
 export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const { session } = await authenticateAdminRequest(request);
@@ -692,9 +670,9 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
         shopId,
         templateLineId: line.templateLineId,
         materialId: line.materialId,
-        quantity: parseNullableWholeNumber(line.overrideQuantity, "Material quantity") ?? 0,
-        yield: parseNullableWholeNumber(line.overrideYield, "Material yield"),
-        usesPerVariant: parseNullableWholeNumber(line.overrideUsesPerVariant, "Material uses per variant"),
+        quantity: parseOptionalNonNegativeWholeNumber(line.overrideQuantity, "Material quantity") ?? 0,
+        yield: parseOptionalNonNegativeWholeNumber(line.overrideYield, "Material yield"),
+        usesPerVariant: parseOptionalNonNegativeWholeNumber(line.overrideUsesPerVariant, "Material uses per variant"),
       }));
 
     const equipmentOverrideLines = draft.templateEquipmentLines
@@ -703,23 +681,23 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
         shopId,
         templateLineId: line.templateLineId,
         equipmentId: line.equipmentId,
-        minutes: parseNullableNumber(line.overrideMinutes, "Equipment minutes"),
-        uses: parseNullableWholeNumber(line.overrideUses, "Equipment uses"),
+        minutes: parseOptionalNonNegativeNumber(line.overrideMinutes, "Equipment minutes"),
+        uses: parseOptionalNonNegativeWholeNumber(line.overrideUses, "Equipment uses"),
       }));
 
     const additionalMaterialLines = draft.materialLines.map((line) => ({
       shopId,
       materialId: line.materialId,
-      quantity: parseNullableWholeNumber(line.quantity, "Material quantity") ?? 0,
-      yield: parseNullableWholeNumber(line.yield, "Material yield"),
-      usesPerVariant: parseNullableWholeNumber(line.usesPerVariant, "Material uses per variant"),
+      quantity: parseOptionalNonNegativeWholeNumber(line.quantity, "Material quantity") ?? 0,
+      yield: parseOptionalNonNegativeWholeNumber(line.yield, "Material yield"),
+      usesPerVariant: parseOptionalNonNegativeWholeNumber(line.usesPerVariant, "Material uses per variant"),
     }));
 
     const additionalEquipmentLines = draft.equipmentLines.map((line) => ({
       shopId,
       equipmentId: line.equipmentId,
-      minutes: parseNullableNumber(line.minutes, "Equipment minutes"),
-      uses: parseNullableWholeNumber(line.uses, "Equipment uses"),
+      minutes: parseOptionalNonNegativeNumber(line.minutes, "Equipment minutes"),
+      uses: parseOptionalNonNegativeWholeNumber(line.uses, "Equipment uses"),
     }));
 
     await prisma.$transaction(async (tx) => {
@@ -731,9 +709,9 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
           data: {
             productionTemplateId: normalizedProductionTemplateId,
             shippingTemplateId: normalizedShippingTemplateId,
-            laborMinutes: parseNullableNumber(draft.laborMinutes, "Labor minutes"),
-            laborRate: parseNullableNumber(draft.laborRate, "Labor rate"),
-            mistakeBuffer: parseOptionalPercent(draft.mistakeBuffer),
+            laborMinutes: parseOptionalNonNegativeNumber(draft.laborMinutes, "Labor minutes"),
+            laborRate: parseOptionalNonNegativeNumber(draft.laborRate, "Labor rate"),
+            mistakeBuffer: parseOptionalPercent(draft.mistakeBuffer, "Mistake buffer"),
             lineItemCount: draft.materialLines.length + draft.equipmentLines.length,
           },
         });
@@ -744,9 +722,9 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
             variantId,
             productionTemplateId: normalizedProductionTemplateId,
             shippingTemplateId: normalizedShippingTemplateId,
-            laborMinutes: parseNullableNumber(draft.laborMinutes, "Labor minutes"),
-            laborRate: parseNullableNumber(draft.laborRate, "Labor rate"),
-            mistakeBuffer: parseOptionalPercent(draft.mistakeBuffer),
+            laborMinutes: parseOptionalNonNegativeNumber(draft.laborMinutes, "Labor minutes"),
+            laborRate: parseOptionalNonNegativeNumber(draft.laborRate, "Labor rate"),
+            mistakeBuffer: parseOptionalPercent(draft.mistakeBuffer, "Mistake buffer"),
             lineItemCount: draft.materialLines.length + draft.equipmentLines.length,
           },
         });

--- a/app/utils/number-parsing.test.ts
+++ b/app/utils/number-parsing.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseOptionalNonNegativeNumber,
+  parseOptionalNonNegativeWholeNumber,
+  parseOptionalPercent,
+  parseRequiredNonNegativeWholeNumber,
+} from "./number-parsing";
+
+async function expectResponseError(callback: () => unknown, message: string) {
+  try {
+    callback();
+  } catch (error) {
+    expect(error).toBeInstanceOf(Response);
+    expect(await (error as Response).text()).toBe(message);
+    return;
+  }
+
+  throw new Error("Expected parser to throw a Response.");
+}
+
+describe("number parsing", () => {
+  it("parses optional non-negative decimals", async () => {
+    expect(parseOptionalNonNegativeNumber("", "Minutes")).toBeNull();
+    expect(parseOptionalNonNegativeNumber("1.5", "Minutes")).toBe(1.5);
+    await expectResponseError(
+      () => parseOptionalNonNegativeNumber("-1", "Minutes"),
+      "Minutes must be a non-negative number.",
+    );
+  });
+
+  it("parses optional non-negative whole numbers", async () => {
+    expect(parseOptionalNonNegativeWholeNumber("", "Material yield")).toBeNull();
+    expect(parseOptionalNonNegativeWholeNumber("3", "Material yield")).toBe(3);
+    await expectResponseError(
+      () => parseOptionalNonNegativeWholeNumber("1.5", "Material yield"),
+      "Material yield must be a non-negative whole number.",
+    );
+  });
+
+  it("requires whole numbers when a value must be present", async () => {
+    expect(parseRequiredNonNegativeWholeNumber("2", "Material quantity")).toBe(2);
+    await expectResponseError(
+      () => parseRequiredNonNegativeWholeNumber("", "Material quantity"),
+      "Material quantity must be a non-negative whole number.",
+    );
+  });
+
+  it("parses optional percent values into decimal rates", async () => {
+    expect(parseOptionalPercent("", "Mistake buffer")).toBeNull();
+    expect(parseOptionalPercent("12.5", "Mistake buffer")).toBe(0.125);
+    await expectResponseError(
+      () => parseOptionalPercent("101", "Mistake buffer"),
+      "Mistake buffer must be between 0 and 100.",
+    );
+  });
+});

--- a/app/utils/number-parsing.ts
+++ b/app/utils/number-parsing.ts
@@ -1,0 +1,37 @@
+export function parseOptionalNonNegativeNumber(value: string | null | undefined, field: string) {
+  if (!value || !value.trim()) return null;
+  const parsed = Number(value);
+  if (Number.isNaN(parsed) || parsed < 0) {
+    throw new Response(`${field} must be a non-negative number.`, { status: 400 });
+  }
+  return parsed;
+}
+
+export function parseOptionalNonNegativeWholeNumber(value: string | null | undefined, field: string) {
+  if (!value || !value.trim()) return null;
+  const parsed = Number(value);
+  if (Number.isNaN(parsed) || parsed < 0 || !Number.isInteger(parsed)) {
+    throw new Response(`${field} must be a non-negative whole number.`, { status: 400 });
+  }
+  return parsed;
+}
+
+export function parseRequiredNonNegativeWholeNumber(value: string | null | undefined, field: string) {
+  if (!value || !value.trim()) {
+    throw new Response(`${field} must be a non-negative whole number.`, { status: 400 });
+  }
+  const parsed = Number(value);
+  if (Number.isNaN(parsed) || parsed < 0 || !Number.isInteger(parsed)) {
+    throw new Response(`${field} must be a non-negative whole number.`, { status: 400 });
+  }
+  return parsed;
+}
+
+export function parseOptionalPercent(value: string | null | undefined, field: string) {
+  if (!value || !value.trim()) return null;
+  const parsed = Number(value);
+  if (Number.isNaN(parsed) || parsed < 0 || parsed > 100) {
+    throw new Response(`${field} must be between 0 and 100.`, { status: 400 });
+  }
+  return parsed / 100;
+}

--- a/prisma/migrations/20260406223000_integer_line_count_constraints/migration.sql
+++ b/prisma/migrations/20260406223000_integer_line_count_constraints/migration.sql
@@ -1,0 +1,26 @@
+-- Enforce whole-number count fields at the database boundary.
+-- Minutes, purchase quantities, percentages, and money remain decimal-valued by design.
+
+ALTER TABLE "CostTemplateMaterialLine"
+  ADD CONSTRAINT "CostTemplateMaterialLine_quantity_whole_nonnegative"
+    CHECK ("quantity" >= 0 AND "quantity" = trunc("quantity")),
+  ADD CONSTRAINT "CostTemplateMaterialLine_yield_whole_nonnegative"
+    CHECK ("yield" IS NULL OR ("yield" >= 0 AND "yield" = trunc("yield"))),
+  ADD CONSTRAINT "CostTemplateMaterialLine_usesPerVariant_whole_nonnegative"
+    CHECK ("usesPerVariant" IS NULL OR ("usesPerVariant" >= 0 AND "usesPerVariant" = trunc("usesPerVariant")));
+
+ALTER TABLE "CostTemplateEquipmentLine"
+  ADD CONSTRAINT "CostTemplateEquipmentLine_uses_whole_nonnegative"
+    CHECK ("uses" IS NULL OR ("uses" >= 0 AND "uses" = trunc("uses")));
+
+ALTER TABLE "VariantMaterialLine"
+  ADD CONSTRAINT "VariantMaterialLine_quantity_whole_nonnegative"
+    CHECK ("quantity" >= 0 AND "quantity" = trunc("quantity")),
+  ADD CONSTRAINT "VariantMaterialLine_yield_whole_nonnegative"
+    CHECK ("yield" IS NULL OR ("yield" >= 0 AND "yield" = trunc("yield"))),
+  ADD CONSTRAINT "VariantMaterialLine_usesPerVariant_whole_nonnegative"
+    CHECK ("usesPerVariant" IS NULL OR ("usesPerVariant" >= 0 AND "usesPerVariant" = trunc("usesPerVariant")));
+
+ALTER TABLE "VariantEquipmentLine"
+  ADD CONSTRAINT "VariantEquipmentLine_uses_whole_nonnegative"
+    CHECK ("uses" IS NULL OR ("uses" >= 0 AND "uses" = trunc("uses")));


### PR DESCRIPTION
## Summary
- Add shared numeric parsers for non-negative decimals, whole-number counts, required whole-number counts, and percentages
- Replace duplicated Template/Variant detail parsing logic with the shared helper
- Add DB check constraints for the agreed whole-number count fields: material quantity/yield/uses-per-variant and equipment uses
- Keep minutes, purchase quantities, percentages, and money decimal-valued by design

## Validation
- `npx prisma validate`
- `npx prisma migrate dev --skip-generate`
- `npx tsc --noEmit`
- `npm run lint` (outside sandbox due known import resolver casing false positives in sandbox path)
- `npm test`
- `npm run test:ui -- --grep "template details|variant details"`

Closes #35