### PR TITLE
Add searchable variant line pickers

### DIFF
--- a/app/components/polaris-shim.tsx
+++ b/app/components/polaris-shim.tsx
@@ -462,15 +462,19 @@ export function Autocomplete({
   onSelect,
   textField,
   emptyState,
+  visibleOptionLimit = 6,
 }: {
   options: AutocompleteOption[];
   selected: string[];
   onSelect: (selected: string[]) => void;
   textField: ReactNode;
   emptyState?: ReactNode;
+  visibleOptionLimit?: number;
 }) {
   const [open, setOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const visibleOptions = options.slice(0, visibleOptionLimit);
+  const hiddenOptionCount = Math.max(options.length - visibleOptions.length, 0);
 
   useEffect(() => {
     function handlePointerDown(event: MouseEvent) {
@@ -498,12 +502,10 @@ export function Autocomplete({
             top: "calc(100% + 0.35rem)",
             left: 0,
             right: 0,
-            zIndex: 20,
+            zIndex: 30,
             border: "1px solid var(--p-color-border, #d2d5d8)",
             borderRadius: "0.75rem",
             overflow: "hidden",
-            maxHeight: "14rem",
-            overflowY: "auto",
             background: "#fff",
             boxShadow: "0 12px 24px rgba(0, 0, 0, 0.12)",
           }}
@@ -511,26 +513,40 @@ export function Autocomplete({
           {options.length === 0 ? (
             <div style={{ padding: "0.75rem 1rem" }}>{emptyState ?? null}</div>
           ) : (
-            options.map((option) => (
-              <button
-                key={option.value}
-                type="button"
-                onClick={() => {
-                  onSelect([option.value]);
-                  setOpen(false);
-                }}
-                style={{
-                  width: "100%",
-                  textAlign: "left",
-                  border: 0,
-                  background: "#fff",
-                  padding: "0.75rem 1rem",
-                  cursor: "pointer",
-                }}
-              >
-                {option.label}
-              </button>
-            ))
+            <>
+              {visibleOptions.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => {
+                    onSelect([option.value]);
+                    setOpen(false);
+                  }}
+                  style={{
+                    width: "100%",
+                    textAlign: "left",
+                    border: 0,
+                    background: "#fff",
+                    padding: "0.75rem 1rem",
+                    cursor: "pointer",
+                  }}
+                >
+                  {option.label}
+                </button>
+              ))}
+              {hiddenOptionCount > 0 && (
+                <div
+                  style={{
+                    padding: "0.65rem 1rem",
+                    borderTop: "1px solid var(--p-color-border, #d2d5d8)",
+                    color: "var(--p-color-text-subdued, #6d7175)",
+                    fontSize: "0.875rem",
+                  }}
+                >
+                  Keep typing to narrow {hiddenOptionCount} more result{hiddenOptionCount === 1 ? "" : "s"}.
+                </div>
+              )}
+            </>
           )}
         </div>
       )}

--- a/app/routes/app.variants.$variantId.tsx
+++ b/app/routes/app.variants.$variantId.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { useFetcher, useLoaderData, useRevalidator, useRouteError } from "@remix-run/react";
 import {
+  Autocomplete,
   Badge,
   Banner,
   BlockStack,
@@ -617,6 +618,14 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
     const additionalMaterialIds = [...new Set(draft.materialLines.map((line) => line.materialId))];
     const additionalEquipmentIds = [...new Set(draft.equipmentLines.map((line) => line.equipmentId))];
 
+    if (additionalMaterialIds.length !== draft.materialLines.length) {
+      return Response.json({ ok: false, message: "Each additional material can only appear once on a variant." }, { status: 400 });
+    }
+
+    if (additionalEquipmentIds.length !== draft.equipmentLines.length) {
+      return Response.json({ ok: false, message: "Each additional equipment item can only appear once on a variant." }, { status: 400 });
+    }
+
     const [materialsFound, equipmentFound, existingConfig] = await Promise.all([
       prisma.materialLibraryItem.findMany({ where: { id: { in: additionalMaterialIds }, shopId }, select: { id: true } }),
       prisma.equipmentLibraryItem.findMany({ where: { id: { in: additionalEquipmentIds }, shopId }, select: { id: true } }),
@@ -1206,6 +1215,13 @@ type AvailableMaterial = {
   totalUsesPerUnit: string | null;
 };
 
+type AvailableEquipment = {
+  id: string;
+  name: string;
+  hourlyRate: string | null;
+  perUseCost: string | null;
+};
+
 function describeMaterialLine(line: {
   costingModel: string | null;
   quantity: string | null;
@@ -1279,7 +1295,8 @@ export default function VariantDetailPage() {
   );
 
   const [addMaterialOpen, setAddMaterialOpen] = useState(false);
-  const [selectedMaterialId, setSelectedMaterialId] = useState(availableMaterials[0]?.id ?? "");
+  const [selectedMaterialId, setSelectedMaterialId] = useState("");
+  const [materialSearchValue, setMaterialSearchValue] = useState("");
   const [matQty, setMatQty] = useState("1");
   const [matYield, setMatYield] = useState("1");
   const [matUses, setMatUses] = useState("");
@@ -1290,7 +1307,8 @@ export default function VariantDetailPage() {
   const [overrideMatUses, setOverrideMatUses] = useState("");
 
   const [addEquipmentOpen, setAddEquipmentOpen] = useState(false);
-  const [selectedEquipmentId, setSelectedEquipmentId] = useState(availableEquipment[0]?.id ?? "");
+  const [selectedEquipmentId, setSelectedEquipmentId] = useState("");
+  const [equipmentSearchValue, setEquipmentSearchValue] = useState("");
   const [eqMinutes, setEqMinutes] = useState("");
   const [eqUses, setEqUses] = useState("");
 
@@ -1319,6 +1337,21 @@ export default function VariantDetailPage() {
   const shippingTemplateMaterialLines = effectiveShippingTemplate?.materialLines ?? [];
   const preview = previewFetcher.data?.preview;
   const selectedMaterial = availableMaterials.find((material: AvailableMaterial) => material.id === selectedMaterialId);
+  const selectedEquipment = availableEquipment.find((equipment: AvailableEquipment) => equipment.id === selectedEquipmentId);
+  const unavailableMaterialIds = new Set(draft.materialLines.map((line: SerializedMaterialLine) => line.materialId));
+  const unavailableEquipmentIds = new Set(draft.equipmentLines.map((line: SerializedEquipmentLine) => line.equipmentId));
+  const filteredMaterialOptions = availableMaterials
+    .filter((material: AvailableMaterial) => !unavailableMaterialIds.has(material.id))
+    .filter((material: AvailableMaterial) =>
+      material.name.toLowerCase().includes(materialSearchValue.trim().toLowerCase()),
+    )
+    .map((material: AvailableMaterial) => ({ label: material.name, value: material.id }));
+  const filteredEquipmentOptions = availableEquipment
+    .filter((equipment: AvailableEquipment) => !unavailableEquipmentIds.has(equipment.id))
+    .filter((equipment: AvailableEquipment) =>
+      equipment.name.toLowerCase().includes(equipmentSearchValue.trim().toLowerCase()),
+    )
+    .map((equipment: AvailableEquipment) => ({ label: equipment.name, value: equipment.id }));
   const additionalProductionMaterialLines = draft.materialLines.filter(
     (line: SerializedMaterialLine) => line.materialType === "production",
   );
@@ -1351,14 +1384,16 @@ export default function VariantDetailPage() {
   }, [draft, revalidator, saveFetcher.data]);
 
   function resetAdditionalMaterialModal() {
-    setSelectedMaterialId(availableMaterials[0]?.id ?? "");
+    setSelectedMaterialId("");
+    setMaterialSearchValue("");
     setMatQty("1");
     setMatYield("1");
     setMatUses("");
   }
 
   function resetAdditionalEquipmentModal() {
-    setSelectedEquipmentId(availableEquipment[0]?.id ?? "");
+    setSelectedEquipmentId("");
+    setEquipmentSearchValue("");
     setEqMinutes("");
     setEqUses("");
   }
@@ -1459,15 +1494,14 @@ export default function VariantDetailPage() {
   }
 
   function addAdditionalEquipmentLine() {
-    const equipment = availableEquipment.find((item: { id: string }) => item.id === selectedEquipmentId);
-    if (!equipment) return;
+    if (!selectedEquipment) return;
 
     const nextLine: SerializedEquipmentLine = {
       id: createClientId("draft-equipment"),
-      equipmentId: equipment.id,
-      equipmentName: equipment.name,
-      hourlyRate: equipment.hourlyRate,
-      perUseCost: equipment.perUseCost,
+      equipmentId: selectedEquipment.id,
+      equipmentName: selectedEquipment.name,
+      hourlyRate: selectedEquipment.hourlyRate,
+      perUseCost: selectedEquipment.perUseCost,
       minutes: eqMinutes || null,
       uses: eqUses || null,
     };
@@ -1838,7 +1872,7 @@ export default function VariantDetailPage() {
                   Add variant-only materials that are not part of the assigned template.
                 </Text>
               </BlockStack>
-              <Button onClick={() => setAddMaterialOpen(true)} disabled={availableMaterials.length === 0}>
+              <Button onClick={() => setAddMaterialOpen(true)} disabled={availableMaterials.length === draft.materialLines.length}>
                 Add material
               </Button>
             </InlineStack>
@@ -1959,7 +1993,7 @@ export default function VariantDetailPage() {
                   Add variant-only equipment usage outside the assigned template.
                 </Text>
               </BlockStack>
-              <Button onClick={() => setAddEquipmentOpen(true)} disabled={availableEquipment.length === 0}>
+              <Button onClick={() => setAddEquipmentOpen(true)} disabled={availableEquipment.length === draft.equipmentLines.length}>
                 Add equipment
               </Button>
             </InlineStack>
@@ -2144,6 +2178,7 @@ export default function VariantDetailPage() {
         primaryAction={{
           content: "Add",
           loading: isSaving,
+          disabled: !selectedMaterialId,
           onAction: addAdditionalMaterialLine,
         }}
         secondaryActions={[{
@@ -2156,16 +2191,31 @@ export default function VariantDetailPage() {
       >
         <Modal.Section>
           <BlockStack gap="400">
-            <Select
-              label="Material"
-              options={availableMaterials.map((material: AvailableMaterial) => ({ label: material.name, value: material.id }))}
-              value={selectedMaterialId}
-              onChange={(value) => {
-                const nextMaterial = availableMaterials.find((material: AvailableMaterial) => material.id === value);
-                setSelectedMaterialId(value);
+            <Autocomplete
+              options={filteredMaterialOptions}
+              selected={selectedMaterialId ? [selectedMaterialId] : []}
+              onSelect={(selected) => {
+                const nextId = selected[0] ?? "";
+                const nextMaterial = availableMaterials.find((material: AvailableMaterial) => material.id === nextId);
+                setSelectedMaterialId(nextId);
+                setMaterialSearchValue(nextMaterial?.name ?? "");
                 setMatYield(nextMaterial?.costingModel === "yield" ? "1" : "");
                 setMatUses("");
               }}
+              textField={
+                <Autocomplete.TextField
+                  label="Material"
+                  value={materialSearchValue}
+                  onChange={setMaterialSearchValue}
+                  autoComplete="off"
+                  placeholder="Search materials"
+                />
+              }
+              emptyState={
+                <Text as="p" variant="bodyMd" tone="subdued">
+                  No matching materials found.
+                </Text>
+              }
             />
             {selectedMaterial?.costingModel === "yield" && (
               <>
@@ -2263,6 +2313,7 @@ export default function VariantDetailPage() {
         primaryAction={{
           content: "Add",
           loading: isSaving,
+          disabled: !selectedEquipmentId,
           onAction: addAdditionalEquipmentLine,
         }}
         secondaryActions={[{
@@ -2275,11 +2326,29 @@ export default function VariantDetailPage() {
       >
         <Modal.Section>
           <BlockStack gap="400">
-            <Select
-              label="Equipment"
-              options={availableEquipment.map((equipment: { id: string; name: string }) => ({ label: equipment.name, value: equipment.id }))}
-              value={selectedEquipmentId}
-              onChange={setSelectedEquipmentId}
+            <Autocomplete
+              options={filteredEquipmentOptions}
+              selected={selectedEquipmentId ? [selectedEquipmentId] : []}
+              onSelect={(selected) => {
+                const nextId = selected[0] ?? "";
+                const nextEquipment = availableEquipment.find((equipment: AvailableEquipment) => equipment.id === nextId);
+                setSelectedEquipmentId(nextId);
+                setEquipmentSearchValue(nextEquipment?.name ?? "");
+              }}
+              textField={
+                <Autocomplete.TextField
+                  label="Equipment"
+                  value={equipmentSearchValue}
+                  onChange={setEquipmentSearchValue}
+                  autoComplete="off"
+                  placeholder="Search equipment"
+                />
+              }
+              emptyState={
+                <Text as="p" variant="bodyMd" tone="subdued">
+                  No matching equipment found.
+                </Text>
+              }
             />
             <InlineStack gap="400" wrap={false}>
               <div style={{ flex: 1 }}>

--- a/app/routes/ui-fixtures.variant-details-bootstrap.tsx
+++ b/app/routes/ui-fixtures.variant-details-bootstrap.tsx
@@ -132,6 +132,13 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     },
   });
 
+  await prisma.equipmentLibraryItem.deleteMany({
+    where: {
+      shopId,
+      name: "Playwright Heat Press",
+    },
+  });
+
   await prisma.materialLibraryItem.create({
     data: {
       shopId,
@@ -156,6 +163,16 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       purchaseQty: "1.00",
       perUnitCost: "3.000000",
       totalUsesPerUnit: null,
+      status: "active",
+    },
+  });
+
+  await prisma.equipmentLibraryItem.create({
+    data: {
+      shopId,
+      name: "Playwright Heat Press",
+      hourlyRate: "12.00",
+      perUseCost: "0.25",
       status: "active",
     },
   });

--- a/tests/ui/variant-details-workflow.spec.ts
+++ b/tests/ui/variant-details-workflow.spec.ts
@@ -38,7 +38,10 @@ test("variant details default new yield-based material lines to 1", async ({ pag
   await page.goto(bootstrap.variantUrl);
 
   await page.getByRole("button", { name: "Add material" }).click();
-  await page.getByLabel("Material", { exact: true }).selectOption({ label: "Playwright Yield Material" });
+  const addDialog = page.getByRole("dialog").filter({ hasText: "Add material line" });
+  await expect(addDialog.getByRole("button", { name: "Add", exact: true })).toBeDisabled();
+  await addDialog.getByPlaceholder("Search materials").click();
+  await addDialog.getByRole("button", { name: "Playwright Yield Material" }).click();
 
   await expect(page.getByLabel("Yield per piece")).toHaveValue("1");
 });
@@ -51,13 +54,42 @@ test("variant details groups additional shipping material lines separately", asy
   await page.goto(bootstrap.variantUrl);
 
   await page.getByRole("button", { name: "Add material" }).click();
-  await page.getByLabel("Material", { exact: true }).selectOption({ label: "ZZZ Playwright Shipping Material" });
-  await page.getByRole("button", { name: "Add", exact: true }).click();
+  let addDialog = page.getByRole("dialog").filter({ hasText: "Add material line" });
+  await addDialog.getByPlaceholder("Search materials").click();
+  await addDialog.getByRole("button", { name: "ZZZ Playwright Shipping Material" }).click();
+  await addDialog.getByRole("button", { name: "Add", exact: true }).click();
 
   await expect(page.getByRole("heading", { name: "Shipping materials" })).toBeVisible();
   await expect(
     page.getByRole("paragraph").filter({ hasText: "ZZZ Playwright Shipping Material" }),
   ).toBeVisible();
+
+  await page.getByRole("button", { name: "Add material" }).click();
+  addDialog = page.getByRole("dialog").filter({ hasText: "Add material line" });
+  await addDialog.getByPlaceholder("Search materials").fill("ZZZ Playwright Shipping Material");
+  await expect(addDialog.getByRole("button", { name: "ZZZ Playwright Shipping Material" })).toHaveCount(0);
+});
+
+test("variant details use searchable equipment add picker and suppress duplicates", async ({ page, request }) => {
+  const bootstrapResponse = await request.get("/ui-fixtures/variant-details-bootstrap");
+  expect(bootstrapResponse.ok()).toBeTruthy();
+
+  const bootstrap = await bootstrapResponse.json();
+  await page.goto(bootstrap.variantUrl);
+
+  await page.getByRole("button", { name: "Add equipment" }).click();
+  let addDialog = page.getByRole("dialog").filter({ hasText: "Add equipment line" });
+  await expect(addDialog.getByRole("button", { name: "Add", exact: true })).toBeDisabled();
+  await addDialog.getByPlaceholder("Search equipment").click();
+  await addDialog.getByRole("button", { name: "Playwright Heat Press" }).click();
+  await addDialog.getByRole("button", { name: "Add", exact: true }).click();
+
+  await expect(page.getByRole("paragraph").filter({ hasText: "Playwright Heat Press" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Add equipment" }).click();
+  addDialog = page.getByRole("dialog").filter({ hasText: "Add equipment line" });
+  await addDialog.getByPlaceholder("Search equipment").fill("Playwright Heat Press");
+  await expect(addDialog.getByRole("button", { name: "Playwright Heat Press" })).toHaveCount(0);
 });
 
 test("variant details persist production and shipping template assignments", async ({ page, request }) => {


### PR DESCRIPTION
## Summary
- Replace Variant additional material/equipment add selects with the same searchable Autocomplete pattern used by Template editing
- Start add dialogs with no preselected record and disable the Add action until a record is chosen
- Suppress already-added variant-only materials/equipment from add-mode search results
- Add server-side duplicate guards for variant-only material/equipment lines
- Extend the variant details Playwright fixture and workflow coverage for material/equipment picker behavior

## Validation
- `npx tsc --noEmit`
- `npm run lint` (outside sandbox due known import resolver casing false positives in sandbox path)
- `npm test`
- `npm run test:ui -- --grep "variant details"`

Closes #18