### PR TITLE
Add Phase 4 reporting period lifecycle foundation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules
 database.sqlite
 
 .env
+.codex
 .env.*
 !.env.example
 !.env.*.example

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,9 +43,11 @@ See [docs/adrs/](docs/adrs/) for ADRs covering immutable order snapshots (ADR-00
 Every `loader` and `action` must begin with:
 
 ```typescript
-const { session } = await authenticate.admin(request);
+const { session } = await authenticateAdminRequest(request);
 const shopId = session.shop;
 ```
+
+`authenticateAdminRequest` lives in `app/utils/admin-auth.server.ts` and supports the Playwright bypass for UI fixtures. Use it for all `/app/*` routes unless a route explicitly must bypass that behavior.
 
 Every database query must include `shopId` in its `where` clause. Never query by a user-supplied ID alone — this is the primary guard against cross-tenant data leakage in a multi-tenant app.
 
@@ -89,6 +91,8 @@ const total = materialCost.add(laborCost).add(equipmentCost);
 // Wrong — floating-point errors corrupt financial calculations
 const total = parseFloat(materialCost.toString()) + parseFloat(laborCost.toString());
 ```
+
+When reading monetary values from `FormData`, parse to `Prisma.Decimal` (or validate with Zod and then convert) before writing to the database.
 
 ### 4. Audit Logging
 
@@ -153,6 +157,7 @@ export function ErrorBoundary() {
 - All status feedback should use `s-banner` paired with a visually-hidden `aria-live="polite"` region so screen readers announce the result.
 - Page titles should use `ui-title-bar`.
 - Destructive or irreversible actions must be gated behind a confirmation dialog or clearly isolated destructive flow.
+- For modal-driven admin flows, prefer native `<dialog>` until `s-modal` interop is proven reliable in this repo.
 
 ### 9. Security
 

--- a/app/db.server.ts
+++ b/app/db.server.ts
@@ -12,6 +12,8 @@ const TENANT_SCOPED_MODELS = [
   "Cause", "ProductCauseAssignment",
   "OrderSnapshot", "OrderSnapshotLine",
   "LineCauseAllocation", "Adjustment",
+  "ReportingPeriod", "CauseAllocation", "Disbursement",
+  "TaxTrueUp", "ShopifyChargeTransaction",
   "BusinessExpense", "TaxOffsetCache",
 ];
 

--- a/app/jobs/processors.server.test.ts
+++ b/app/jobs/processors.server.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
     auditLog: { create: vi.fn() },
   },
   runReconciliation: vi.fn(),
+  createReportingPeriodFromPayout: vi.fn(),
   adminFactory: vi.fn(),
 }));
 
@@ -26,6 +27,10 @@ vi.mock("../services/adjustmentService.server", () => ({
 
 vi.mock("../services/reconciliationService.server", () => ({
   runReconciliation: mocks.runReconciliation,
+}));
+
+vi.mock("../services/reportingPeriodService.server", () => ({
+  createReportingPeriodFromPayout: mocks.createReportingPeriodFromPayout,
 }));
 
 vi.mock("../services/snapshotService.server", () => ({
@@ -114,6 +119,24 @@ describe("registerAllProcessors", () => {
           action: "RECONCILIATION_RUN_FAILED",
         }),
       }),
+    );
+  });
+
+  it("opens reporting periods from payout webhooks", async () => {
+    const boss = createBoss();
+    const payoutPayload = { id: 123, date: "2026-04-07" };
+
+    await registerAllProcessors(boss as any);
+
+    const worker = boss.workers.get("reporting.period.open");
+    expect(worker).toBeTruthy();
+
+    await worker!([{ data: { shopId: "shop-1", payload: payoutPayload } }]);
+
+    expect(mocks.createReportingPeriodFromPayout).toHaveBeenCalledWith(
+      "shop-1",
+      payoutPayload,
+      mocks.prisma,
     );
   });
 });

--- a/app/jobs/processors.server.test.ts
+++ b/app/jobs/processors.server.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   },
   runReconciliation: vi.fn(),
   createReportingPeriodFromPayout: vi.fn(),
+  syncShopifyCharges: vi.fn(),
   adminFactory: vi.fn(),
 }));
 
@@ -18,6 +19,10 @@ vi.mock("../db.server", () => ({
 vi.mock("../services/catalogSync.server", () => ({
   fullSync: vi.fn(),
   incrementalSync: vi.fn(),
+}));
+
+vi.mock("../services/chargeSyncService.server", () => ({
+  syncShopifyCharges: mocks.syncShopifyCharges,
 }));
 
 vi.mock("../services/adjustmentService.server", () => ({
@@ -137,6 +142,59 @@ describe("registerAllProcessors", () => {
       "shop-1",
       payoutPayload,
       mocks.prisma,
+    );
+  });
+
+  it("fans daily Shopify charge sync out into singleton per-shop jobs", async () => {
+    const boss = createBoss();
+    mocks.prisma.shop.findMany.mockResolvedValue([{ shopId: "shop-1" }, { shopId: "shop-2" }]);
+
+    await registerAllProcessors(boss as any);
+
+    const dailyWorker = boss.workers.get("shopify-charges.daily");
+    expect(dailyWorker).toBeTruthy();
+
+    await dailyWorker!([]);
+
+    expect(boss.send).toHaveBeenNthCalledWith(
+      1,
+      "shopify-charges.shop",
+      { shopId: "shop-1" },
+      expect.objectContaining({
+        singletonKey: "shop-1",
+        singletonSeconds: 6 * 60 * 60,
+      }),
+    );
+    expect(boss.send).toHaveBeenNthCalledWith(
+      2,
+      "shopify-charges.shop",
+      { shopId: "shop-2" },
+      expect.objectContaining({
+        singletonKey: "shop-2",
+        singletonSeconds: 6 * 60 * 60,
+      }),
+    );
+  });
+
+  it("logs Shopify charge sync failures per shop and rethrows them", async () => {
+    const boss = createBoss();
+    const error = new Error("Payments API timeout");
+    mocks.adminFactory.mockResolvedValue({ admin: { graphql: vi.fn() } });
+    mocks.syncShopifyCharges.mockRejectedValue(error);
+
+    await registerAllProcessors(boss as any);
+
+    const worker = boss.workers.get("shopify-charges.shop");
+    expect(worker).toBeTruthy();
+
+    await expect(worker!([{ data: { shopId: "shop-1" } }])).rejects.toThrow("Payments API timeout");
+    expect(mocks.prisma.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          shopId: "shop-1",
+          action: "SHOPIFY_CHARGES_SYNC_FAILED",
+        }),
+      }),
     );
   });
 });

--- a/app/jobs/processors.server.ts
+++ b/app/jobs/processors.server.ts
@@ -3,6 +3,7 @@ import { prisma } from "../db.server";
 import { fullSync, incrementalSync } from "../services/catalogSync.server";
 import { processOrderUpdate, processRefund } from "../services/adjustmentService.server";
 import { runReconciliation } from "../services/reconciliationService.server";
+import { createReportingPeriodFromPayout } from "../services/reportingPeriodService.server";
 import { createSnapshot } from "../services/snapshotService.server";
 import { unauthenticated } from "../shopify.server";
 
@@ -14,6 +15,7 @@ const QUEUES = [
   "orders.refund",
   "reconciliation.daily",
   "reconciliation.shop",
+  "reporting.period.open",
   "shop.delete",
   "webhook.compliance",
   "catalog.sync",
@@ -112,6 +114,16 @@ export async function registerAllProcessors(boss: PgBoss): Promise<void> {
       throw error;
     }
   });
+
+  await boss.work<{ shopId: string; payload?: unknown }>(
+    "reporting.period.open",
+    async (jobs) => {
+      const job = jobs[0];
+      if (!job) return;
+      const { shopId, payload } = job.data;
+      await createReportingPeriodFromPayout(shopId, payload as any, prisma);
+    },
+  );
 
   await boss.work<{ shopId: string; deletionJobId: string }>(
     "shop.delete",

--- a/app/jobs/processors.server.ts
+++ b/app/jobs/processors.server.ts
@@ -1,5 +1,6 @@
 import type { PgBoss } from "pg-boss";
 import { prisma } from "../db.server";
+import { syncShopifyCharges } from "../services/chargeSyncService.server";
 import { fullSync, incrementalSync } from "../services/catalogSync.server";
 import { processOrderUpdate, processRefund } from "../services/adjustmentService.server";
 import { runReconciliation } from "../services/reconciliationService.server";
@@ -15,6 +16,8 @@ const QUEUES = [
   "orders.refund",
   "reconciliation.daily",
   "reconciliation.shop",
+  "shopify-charges.daily",
+  "shopify-charges.shop",
   "reporting.period.open",
   "shop.delete",
   "webhook.compliance",
@@ -114,6 +117,50 @@ export async function registerAllProcessors(boss: PgBoss): Promise<void> {
       throw error;
     }
   });
+
+  await boss.work("shopify-charges.daily", async () => {
+    const shops = await prisma.shop.findMany({
+      select: { shopId: true },
+    });
+
+    for (const shop of shops) {
+      await boss.send(
+        "shopify-charges.shop",
+        { shopId: shop.shopId },
+        {
+          singletonKey: shop.shopId,
+          singletonSeconds: 6 * 60 * 60,
+        },
+      );
+    }
+  });
+
+  await boss.work<{ shopId: string; payoutId?: string; payoutDate?: string }>(
+    "shopify-charges.shop",
+    async (jobs) => {
+      const job = jobs[0];
+      if (!job) return;
+
+      const { shopId, payoutId, payoutDate } = job.data;
+      try {
+        const { admin } = await unauthenticated.admin(shopId);
+        await syncShopifyCharges({ shopId, admin, payoutId, payoutDate, db: prisma });
+      } catch (error) {
+        await prisma.auditLog.create({
+          data: {
+            shopId,
+            entity: "ShopifyChargeTransaction",
+            action: "SHOPIFY_CHARGES_SYNC_FAILED",
+            actor: "system",
+            payload: {
+              message: error instanceof Error ? error.message : "Unknown Shopify charges sync failure",
+            },
+          },
+        });
+        throw error;
+      }
+    },
+  );
 
   await boss.work<{ shopId: string; payload?: unknown }>(
     "reporting.period.open",

--- a/app/jobs/queue.server.ts
+++ b/app/jobs/queue.server.ts
@@ -43,6 +43,7 @@ export async function startJobQueue(): Promise<void> {
   // Recurring jobs
   await jobQueue.schedule("plan.detect.daily", "0 6 * * *", {});
   await jobQueue.schedule("reconciliation.daily", "0 3 * * *", {});
+  await jobQueue.schedule("shopify-charges.daily", "0 4 * * *", {});
 
   // Graceful shutdown
   process.on("SIGTERM", async () => {

--- a/app/services/chargeSyncService.server.test.ts
+++ b/app/services/chargeSyncService.server.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { syncShopifyCharges } from "./chargeSyncService.server";
+
+const { createOrOpenReportingPeriod } = vi.hoisted(() => ({
+  createOrOpenReportingPeriod: vi.fn(),
+}));
+
+vi.mock("./reportingPeriodService.server", () => ({
+  createOrOpenReportingPeriod,
+}));
+
+function createResponse(payload: unknown) {
+  return {
+    json: async () => payload,
+  } as Response;
+}
+
+describe("syncShopifyCharges", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("imports Shopify Payments balance transactions idempotently", async () => {
+    createOrOpenReportingPeriod.mockResolvedValue({ id: "period-1" });
+
+    const admin = {
+      graphql: vi.fn().mockResolvedValue(
+        createResponse({
+          data: {
+            shopifyPaymentsAccount: {
+              balanceTransactions: {
+                pageInfo: { hasNextPage: false },
+                edges: [
+                  {
+                    cursor: "cursor-1",
+                    node: {
+                      id: "gid://shopify/ShopifyPaymentsBalanceTransaction/1",
+                      type: "shipping_label",
+                      test: false,
+                      transactionDate: "2026-04-07T12:00:00Z",
+                      associatedPayout: {
+                        id: "gid://shopify/ShopifyPaymentsPayout/900",
+                        issuedAt: "2026-04-08T00:00:00Z",
+                      },
+                      amount: { amount: "-12.00", currencyCode: "USD" },
+                      fee: { amount: "-2.50", currencyCode: "USD" },
+                      net: { amount: "-14.50", currencyCode: "USD" },
+                    },
+                  },
+                  {
+                    cursor: "cursor-2",
+                    node: {
+                      id: "gid://shopify/ShopifyPaymentsBalanceTransaction/2",
+                      type: "adjustment",
+                      test: false,
+                      transactionDate: "2026-04-07T13:00:00Z",
+                      associatedPayout: {
+                        id: "gid://shopify/ShopifyPaymentsPayout/900",
+                        issuedAt: "2026-04-08T00:00:00Z",
+                      },
+                      amount: { amount: "-5.00", currencyCode: "USD" },
+                      fee: { amount: "0.00", currencyCode: "USD" },
+                      net: { amount: "-5.00", currencyCode: "USD" },
+                    },
+                  },
+                  {
+                    cursor: "cursor-3",
+                    node: {
+                      id: "gid://shopify/ShopifyPaymentsBalanceTransaction/3",
+                      type: "charge",
+                      test: false,
+                      transactionDate: "2026-04-07T14:00:00Z",
+                      associatedPayout: {
+                        id: "gid://shopify/ShopifyPaymentsPayout/900",
+                        issuedAt: "2026-04-08T00:00:00Z",
+                      },
+                      amount: { amount: "20.00", currencyCode: "USD" },
+                      net: { amount: "20.00", currencyCode: "USD" },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        }),
+      ),
+    };
+    const createMany = vi
+      .fn()
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValueOnce({ count: 0 });
+    const auditLogCreate = vi.fn().mockResolvedValue(undefined);
+    const db = {
+      shopifyChargeTransaction: {
+        createMany,
+      },
+      auditLog: {
+        create: auditLogCreate,
+      },
+    };
+
+    const result = await syncShopifyCharges({
+      shopId: "shop-1",
+      admin,
+      payoutId: "900",
+      payoutDate: "2026-04-08",
+      db: db as any,
+    });
+
+    expect(admin.graphql).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        variables: {
+          cursor: null,
+          query: "payments_transfer_id:900 payout_date:2026-04-08",
+        },
+      },
+    );
+    expect(createOrOpenReportingPeriod).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shopId: "shop-1",
+        shopifyPayoutId: "900",
+      }),
+      db,
+    );
+    expect(createMany).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        data: [
+          expect.objectContaining({
+            shopifyTransactionId: "gid://shopify/ShopifyPaymentsBalanceTransaction/1",
+            shopifyPayoutId: "900",
+            amount: expect.objectContaining({ toString: expect.any(Function) }),
+            currency: "USD",
+          }),
+        ],
+        skipDuplicates: true,
+      }),
+    );
+    expect(result).toEqual({ imported: 1, skipped: 2 });
+    expect(auditLogCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          action: "SHOPIFY_CHARGES_SYNCED",
+          payload: expect.objectContaining({
+            imported: 1,
+            skipped: 2,
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("paginates balance transactions", async () => {
+    createOrOpenReportingPeriod.mockResolvedValue({ id: "period-1" });
+
+    const admin = {
+      graphql: vi
+        .fn()
+        .mockResolvedValueOnce(
+          createResponse({
+            data: {
+              shopifyPaymentsAccount: {
+                balanceTransactions: {
+                  pageInfo: { hasNextPage: true },
+                  edges: [
+                    {
+                      cursor: "cursor-1",
+                      node: {
+                        id: "transaction-1",
+                        transactionDate: "2026-04-07T12:00:00Z",
+                        amount: { amount: "-1.00", currencyCode: "USD" },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          createResponse({
+            data: {
+              shopifyPaymentsAccount: {
+                balanceTransactions: {
+                  pageInfo: { hasNextPage: false },
+                  edges: [
+                    {
+                      cursor: "cursor-2",
+                      node: {
+                        id: "transaction-2",
+                        transactionDate: "2026-04-07T13:00:00Z",
+                        amount: { amount: "-2.00", currencyCode: "USD" },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          }),
+        ),
+    };
+    const db = {
+      shopifyChargeTransaction: {
+        createMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      auditLog: {
+        create: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+
+    await syncShopifyCharges({
+      shopId: "shop-1",
+      admin,
+      since: new Date("2026-04-01T00:00:00Z"),
+      db: db as any,
+    });
+
+    expect(admin.graphql).toHaveBeenNthCalledWith(
+      2,
+      expect.any(String),
+      expect.objectContaining({
+        variables: expect.objectContaining({
+          cursor: "cursor-1",
+        }),
+      }),
+    );
+  });
+});

--- a/app/services/chargeSyncService.server.ts
+++ b/app/services/chargeSyncService.server.ts
@@ -1,0 +1,287 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "../db.server";
+import { createOrOpenReportingPeriod } from "./reportingPeriodService.server";
+
+type AdminContext = {
+  graphql: (query: string, options?: { variables?: Record<string, unknown> }) => Promise<Response>;
+};
+
+type ShopifyMoney = {
+  amount?: string | null;
+  currencyCode?: string | null;
+};
+
+type BalanceTransactionNode = {
+  id: string;
+  type?: string | null;
+  test?: boolean | null;
+  transactionDate?: string | null;
+  associatedPayout?: {
+    id?: string | null;
+    issuedAt?: string | null;
+  } | null;
+  amount?: ShopifyMoney | null;
+  fee?: ShopifyMoney | null;
+  net?: ShopifyMoney | null;
+};
+
+type BalanceTransactionEdge = {
+  cursor: string;
+  node: BalanceTransactionNode;
+};
+
+type BalanceTransactionsConnection = {
+  pageInfo?: { hasNextPage?: boolean };
+  edges?: BalanceTransactionEdge[];
+};
+
+type BalanceTransactionsPayload = {
+  data?: {
+    shopifyPaymentsAccount?: {
+      balanceTransactions?: BalanceTransactionsConnection | null;
+    } | null;
+  };
+  errors?: Array<{ message?: string }>;
+};
+
+type SyncShopifyChargesInput = {
+  shopId: string;
+  admin: AdminContext;
+  payoutId?: string | null;
+  payoutDate?: string | null;
+  since?: Date;
+  until?: Date;
+  db?: typeof prisma;
+};
+
+const BALANCE_TRANSACTIONS_QUERY = `#graphql
+  query ShopifyPaymentsBalanceTransactions($cursor: String, $query: String!) {
+    shopifyPaymentsAccount {
+      balanceTransactions(first: 100, after: $cursor, query: $query) {
+        pageInfo {
+          hasNextPage
+        }
+        edges {
+          cursor
+          node {
+            id
+            type
+            test
+            transactionDate
+            associatedPayout {
+              id
+              issuedAt
+            }
+            amount {
+              amount
+              currencyCode
+            }
+            fee {
+              amount
+              currencyCode
+            }
+            net {
+              amount
+              currencyCode
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+function toDateInput(date: Date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function recentSyncStart() {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() - 7);
+  return date;
+}
+
+function buildBalanceTransactionQuery(input: {
+  payoutId?: string | null;
+  payoutDate?: string | null;
+  since?: Date;
+  until?: Date;
+}) {
+  const parts: string[] = [];
+
+  if (input.payoutId) {
+    parts.push(`payments_transfer_id:${input.payoutId}`);
+  }
+
+  if (input.payoutDate) {
+    parts.push(`payout_date:${input.payoutDate}`);
+  }
+
+  if (input.since) {
+    parts.push(`transaction_date:>=${toDateInput(input.since)}`);
+  }
+
+  if (input.until) {
+    parts.push(`transaction_date:<${toDateInput(input.until)}`);
+  }
+
+  return parts.join(" ");
+}
+
+function parseDate(value: string | null | undefined) {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function decimalFromMoney(value: ShopifyMoney | null | undefined) {
+  return new Prisma.Decimal(value?.amount ?? "0");
+}
+
+function netEffect(transaction: BalanceTransactionNode) {
+  const net = decimalFromMoney(transaction.net);
+  if (!net.equals(0)) return net;
+
+  return decimalFromMoney(transaction.amount);
+}
+
+function isShopifyCharge(transaction: BalanceTransactionNode) {
+  return netEffect(transaction).lessThan(0);
+}
+
+function chooseChargeAmount(transaction: BalanceTransactionNode) {
+  return netEffect(transaction).abs();
+}
+
+function normalizeShopifyPayoutId(value: string | null | undefined) {
+  if (!value) return null;
+  const match = value.match(/\/([^/]+)$/);
+  return match?.[1] ?? value;
+}
+
+async function readGraphqlPayload<T>(
+  admin: AdminContext,
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<T> {
+  const response = await admin.graphql(query, { variables });
+  const payload = await response.json();
+
+  if (payload?.errors?.length) {
+    throw new Error(`Shopify GraphQL error: ${payload.errors[0]?.message ?? "Unknown error"}`);
+  }
+
+  return payload as T;
+}
+
+async function fetchBalanceTransactions(
+  admin: AdminContext,
+  searchQuery: string,
+): Promise<BalanceTransactionNode[]> {
+  const transactions: BalanceTransactionNode[] = [];
+  let cursor: string | null = null;
+
+  do {
+    const payload: BalanceTransactionsPayload = await readGraphqlPayload<BalanceTransactionsPayload>(
+      admin,
+      BALANCE_TRANSACTIONS_QUERY,
+      { cursor, query: searchQuery },
+    );
+    const connection: BalanceTransactionsConnection | null | undefined =
+      payload.data?.shopifyPaymentsAccount?.balanceTransactions;
+    const edges: BalanceTransactionEdge[] = connection?.edges ?? [];
+
+    transactions.push(...edges.map((edge) => edge.node));
+    cursor = connection?.pageInfo?.hasNextPage ? edges.at(-1)?.cursor ?? null : null;
+  } while (cursor);
+
+  return transactions;
+}
+
+async function ensurePeriodForTransaction(
+  shopId: string,
+  transaction: BalanceTransactionNode,
+  db: typeof prisma,
+) {
+  const payoutId = normalizeShopifyPayoutId(transaction.associatedPayout?.id);
+  const transactionDate = parseDate(transaction.transactionDate) ?? new Date();
+  const payoutDate = parseDate(transaction.associatedPayout?.issuedAt) ?? transactionDate;
+  const startDate = new Date(Date.UTC(transactionDate.getUTCFullYear(), transactionDate.getUTCMonth(), transactionDate.getUTCDate()));
+  const endDate = new Date(Date.UTC(payoutDate.getUTCFullYear(), payoutDate.getUTCMonth(), payoutDate.getUTCDate() + 1));
+
+  return createOrOpenReportingPeriod(
+    {
+      shopId,
+      startDate,
+      endDate: endDate > startDate ? endDate : new Date(startDate.getTime() + 24 * 60 * 60 * 1000),
+      shopifyPayoutId: payoutId,
+      source: payoutId ? "payout" : "charge-sync",
+    },
+    db,
+  );
+}
+
+export async function syncShopifyCharges(input: SyncShopifyChargesInput) {
+  const db = input.db ?? prisma;
+  const searchQuery = buildBalanceTransactionQuery({
+    payoutId: input.payoutId,
+    payoutDate: input.payoutDate,
+    since: input.since ?? (input.payoutId || input.payoutDate ? undefined : recentSyncStart()),
+    until: input.until,
+  });
+  const transactions = await fetchBalanceTransactions(input.admin, searchQuery);
+  let imported = 0;
+  let skipped = 0;
+
+  for (const transaction of transactions) {
+    if (!isShopifyCharge(transaction)) {
+      skipped += 1;
+      continue;
+    }
+
+    const payoutId = normalizeShopifyPayoutId(transaction.associatedPayout?.id) ?? input.payoutId ?? null;
+    const period = await ensurePeriodForTransaction(input.shopId, transaction, db);
+    const created = await db.shopifyChargeTransaction.createMany({
+      data: [
+        {
+          shopId: input.shopId,
+          shopifyTransactionId: transaction.id,
+          periodId: period.id,
+          shopifyPayoutId: payoutId,
+          transactionType: transaction.type ?? null,
+          description: transaction.test ? "Test Shopify Payments transaction" : null,
+          amount: chooseChargeAmount(transaction),
+          currency:
+            transaction.fee?.currencyCode ??
+            transaction.amount?.currencyCode ??
+            transaction.net?.currencyCode ??
+            "USD",
+          processedAt: parseDate(transaction.transactionDate),
+        },
+      ],
+      skipDuplicates: true,
+    });
+
+    if (created.count > 0) {
+      imported += created.count;
+    } else {
+      skipped += 1;
+    }
+  }
+
+  await db.auditLog.create({
+    data: {
+      shopId: input.shopId,
+      entity: "ShopifyChargeTransaction",
+      action: "SHOPIFY_CHARGES_SYNCED",
+      actor: "system",
+      payload: {
+        imported,
+        skipped,
+        query: searchQuery,
+      },
+    },
+  });
+
+  return { imported, skipped };
+}

--- a/app/services/reportingPeriodService.server.test.ts
+++ b/app/services/reportingPeriodService.server.test.ts
@@ -1,0 +1,259 @@
+import { Prisma } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  closeReportingPeriod,
+  createOrOpenReportingPeriod,
+  createReportingPeriodFromPayout,
+  materializeCauseAllocationsForPeriod,
+} from "./reportingPeriodService.server";
+
+function decimal(value: string | number) {
+  return new Prisma.Decimal(value);
+}
+
+describe("createOrOpenReportingPeriod", () => {
+  it("upserts payout-backed reporting periods by Shopify payout id", async () => {
+    const upsert = vi.fn().mockResolvedValue({ id: "period-1" });
+    const db = {
+      reportingPeriod: { upsert },
+    };
+
+    await createOrOpenReportingPeriod(
+      {
+        shopId: "shop-1",
+        startDate: new Date("2026-04-01T00:00:00.000Z"),
+        endDate: new Date("2026-04-08T00:00:00.000Z"),
+        shopifyPayoutId: "payout-1",
+      },
+      db as any,
+    );
+
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          shopId_shopifyPayoutId: {
+            shopId: "shop-1",
+            shopifyPayoutId: "payout-1",
+          },
+        },
+        create: expect.objectContaining({
+          source: "payout",
+        }),
+      }),
+    );
+  });
+
+  it("rejects invalid date ranges", async () => {
+    await expect(
+      createOrOpenReportingPeriod(
+        {
+          shopId: "shop-1",
+          startDate: new Date("2026-04-08T00:00:00.000Z"),
+          endDate: new Date("2026-04-01T00:00:00.000Z"),
+        },
+        {} as any,
+      ),
+    ).rejects.toThrow("endDate must be after startDate");
+  });
+});
+
+describe("createReportingPeriodFromPayout", () => {
+  it("creates payout-backed periods from Shopify payout payloads", async () => {
+    const findFirst = vi.fn().mockResolvedValue({ endDate: new Date("2026-04-01T00:00:00.000Z") });
+    const upsert = vi.fn().mockResolvedValue({ id: "period-1" });
+    const db = {
+      reportingPeriod: {
+        findFirst,
+        upsert,
+      },
+    };
+
+    await createReportingPeriodFromPayout(
+      "shop-1",
+      {
+        id: 123,
+        date: "2026-04-07",
+      },
+      db as any,
+    );
+
+    expect(findFirst).toHaveBeenCalledWith({
+      where: { shopId: "shop-1" },
+      orderBy: { endDate: "desc" },
+      select: { endDate: true },
+    });
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          shopId_shopifyPayoutId: {
+            shopId: "shop-1",
+            shopifyPayoutId: "123",
+          },
+        },
+        create: expect.objectContaining({
+          startDate: new Date("2026-04-01T00:00:00.000Z"),
+          endDate: new Date("2026-04-08T00:00:00.000Z"),
+          source: "payout",
+        }),
+      }),
+    );
+  });
+});
+
+describe("materializeCauseAllocationsForPeriod", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("materializes cause allocation totals with proportional adjustments", async () => {
+    const deleteMany = vi.fn().mockResolvedValue(undefined);
+    const createMany = vi.fn().mockResolvedValue(undefined);
+    const db = {
+      orderSnapshotLine: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            netContribution: decimal("100"),
+            adjustments: [{ netContribAdj: decimal("-25") }],
+            causeAllocations: [
+              {
+                causeId: "cause-1",
+                causeName: "Cause One",
+                is501c3: true,
+                amount: decimal("60"),
+              },
+              {
+                causeId: "cause-2",
+                causeName: "Cause Two",
+                is501c3: false,
+                amount: decimal("40"),
+              },
+            ],
+          },
+          {
+            netContribution: decimal("50"),
+            adjustments: [],
+            causeAllocations: [
+              {
+                causeId: "cause-1",
+                causeName: "Cause One",
+                is501c3: true,
+                amount: decimal("10"),
+              },
+            ],
+          },
+        ]),
+      },
+      causeAllocation: {
+        deleteMany,
+        createMany,
+      },
+    };
+
+    const result = await materializeCauseAllocationsForPeriod(
+      "shop-1",
+      {
+        id: "period-1",
+        startDate: new Date("2026-04-01T00:00:00.000Z"),
+        endDate: new Date("2026-04-08T00:00:00.000Z"),
+      },
+      db as any,
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result.find((row) => row.causeId === "cause-1")?.allocated.toString()).toBe("55");
+    expect(result.find((row) => row.causeId === "cause-2")?.allocated.toString()).toBe("30");
+    expect(deleteMany).toHaveBeenCalledWith({
+      where: {
+        shopId: "shop-1",
+        periodId: "period-1",
+      },
+    });
+    expect(createMany).toHaveBeenCalledWith({
+      data: expect.arrayContaining([
+        expect.objectContaining({
+          causeId: "cause-1",
+          allocated: expect.any(Prisma.Decimal),
+        }),
+      ]),
+    });
+  });
+});
+
+describe("closeReportingPeriod", () => {
+  it("moves an open period through closing to closed and audit logs it", async () => {
+    const period = {
+      id: "period-1",
+      shopId: "shop-1",
+      status: "OPEN",
+      startDate: new Date("2026-04-01T00:00:00.000Z"),
+      endDate: new Date("2026-04-08T00:00:00.000Z"),
+    };
+    const closedAt = new Date("2026-04-08T12:00:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(closedAt);
+
+    const tx = {
+      reportingPeriod: {
+        findFirst: vi.fn().mockResolvedValue(period),
+        update: vi
+          .fn()
+          .mockResolvedValueOnce({ ...period, status: "CLOSING" })
+          .mockResolvedValueOnce({ ...period, status: "CLOSED", closedAt }),
+      },
+      orderSnapshot: {
+        updateMany: vi.fn().mockResolvedValue(undefined),
+      },
+      orderSnapshotLine: {
+        findMany: vi.fn().mockResolvedValue([]),
+      },
+      causeAllocation: {
+        deleteMany: vi.fn().mockResolvedValue(undefined),
+        createMany: vi.fn().mockResolvedValue(undefined),
+        findMany: vi.fn().mockResolvedValue([]),
+      },
+      auditLog: {
+        create: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+    const db = {
+      $transaction: vi.fn().mockImplementation((callback) => callback(tx)),
+    };
+
+    const result = await closeReportingPeriod("shop-1", "period-1", db as any);
+
+    expect(result.closed).toBe(true);
+    expect(tx.reportingPeriod.update).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ data: { status: "CLOSING" } }),
+    );
+    expect(tx.orderSnapshot.updateMany).toHaveBeenCalledWith({
+      where: {
+        shopId: "shop-1",
+        createdAt: {
+          gte: period.startDate,
+          lt: period.endDate,
+        },
+      },
+      data: { periodId: "period-1" },
+    });
+    expect(tx.reportingPeriod.update).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        data: {
+          status: "CLOSED",
+          closedAt,
+        },
+      }),
+    );
+    expect(tx.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          entity: "ReportingPeriod",
+          action: "REPORTING_PERIOD_CLOSED",
+        }),
+      }),
+    );
+
+    vi.useRealTimers();
+  });
+});

--- a/app/services/reportingPeriodService.server.ts
+++ b/app/services/reportingPeriodService.server.ts
@@ -1,0 +1,318 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "../db.server";
+
+const ZERO = new Prisma.Decimal(0);
+const ADJUSTMENT_RATIO_GUARD = new Prisma.Decimal(10);
+
+type DbClient = typeof prisma;
+
+type ReportingPeriodInput = {
+  shopId: string;
+  startDate: Date;
+  endDate: Date;
+  shopifyPayoutId?: string | null;
+  source?: string;
+};
+
+type PayoutPayload = {
+  id?: string | number;
+  admin_graphql_api_id?: string;
+  period_start?: string;
+  period_end?: string;
+  date?: string;
+  issued_at?: string;
+  created_at?: string;
+};
+
+type AllocationDraft = {
+  causeId: string;
+  causeName: string;
+  is501c3: boolean;
+  allocated: Prisma.Decimal;
+};
+
+function addAllocation(
+  allocations: Map<string, AllocationDraft>,
+  input: AllocationDraft,
+) {
+  const current = allocations.get(input.causeId);
+  if (!current) {
+    allocations.set(input.causeId, input);
+    return;
+  }
+
+  allocations.set(input.causeId, {
+    ...current,
+    allocated: current.allocated.add(input.allocated),
+  });
+}
+
+function computeAdjustedAllocationAmount({
+  baseAmount,
+  lineNetContribution,
+  lineAdjustmentTotal,
+}: {
+  baseAmount: Prisma.Decimal;
+  lineNetContribution: Prisma.Decimal;
+  lineAdjustmentTotal: Prisma.Decimal;
+}) {
+  if (lineNetContribution.equals(0) || lineAdjustmentTotal.equals(0)) {
+    return baseAmount;
+  }
+
+  const adjustmentRatio = lineAdjustmentTotal.div(lineNetContribution);
+  if (adjustmentRatio.abs().greaterThan(ADJUSTMENT_RATIO_GUARD)) {
+    return baseAmount;
+  }
+
+  return baseAmount.add(baseAmount.mul(adjustmentRatio));
+}
+
+export async function createOrOpenReportingPeriod(
+  input: ReportingPeriodInput,
+  db: DbClient = prisma,
+) {
+  if (input.endDate <= input.startDate) {
+    throw new Error("Reporting period endDate must be after startDate.");
+  }
+
+  if (input.shopifyPayoutId) {
+    return db.reportingPeriod.upsert({
+      where: {
+        shopId_shopifyPayoutId: {
+          shopId: input.shopId,
+          shopifyPayoutId: input.shopifyPayoutId,
+        },
+      },
+      create: {
+        shopId: input.shopId,
+        startDate: input.startDate,
+        endDate: input.endDate,
+        shopifyPayoutId: input.shopifyPayoutId,
+        source: input.source ?? "payout",
+      },
+      update: {},
+    });
+  }
+
+  return db.reportingPeriod.create({
+    data: {
+      shopId: input.shopId,
+      startDate: input.startDate,
+      endDate: input.endDate,
+      source: input.source ?? "manual",
+    },
+  });
+}
+
+function startOfUtcDay(date: Date) {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+function addUtcDays(date: Date, days: number) {
+  const next = new Date(date);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+function parseDate(value: string | undefined) {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+export async function createReportingPeriodFromPayout(
+  shopId: string,
+  payload: PayoutPayload,
+  db: DbClient = prisma,
+) {
+  const shopifyPayoutId = payload.admin_graphql_api_id ?? payload.id?.toString();
+  if (!shopifyPayoutId) {
+    throw new Error("Payout payload is missing an id.");
+  }
+
+  const explicitEndDate = parseDate(payload.period_end);
+  const rawEndDate =
+    explicitEndDate ??
+    parseDate(payload.date) ??
+    parseDate(payload.issued_at) ??
+    parseDate(payload.created_at) ??
+    new Date();
+  const previousPeriod = await db.reportingPeriod.findFirst({
+    where: { shopId },
+    orderBy: { endDate: "desc" },
+    select: { endDate: true },
+  });
+  const explicitStartDate = parseDate(payload.period_start);
+  const endDate = explicitEndDate ?? addUtcDays(startOfUtcDay(rawEndDate), 1);
+  const startDate = explicitStartDate ?? previousPeriod?.endDate ?? startOfUtcDay(rawEndDate);
+
+  return createOrOpenReportingPeriod(
+    {
+      shopId,
+      startDate,
+      endDate,
+      shopifyPayoutId,
+      source: "payout",
+    },
+    db,
+  );
+}
+
+export async function materializeCauseAllocationsForPeriod(
+  shopId: string,
+  period: { id: string; startDate: Date; endDate: Date },
+  db: DbClient = prisma,
+) {
+  const snapshotLines = await db.orderSnapshotLine.findMany({
+    where: {
+      shopId,
+      snapshot: {
+        createdAt: {
+          gte: period.startDate,
+          lt: period.endDate,
+        },
+      },
+    },
+    select: {
+      netContribution: true,
+      adjustments: {
+        select: { netContribAdj: true },
+      },
+      causeAllocations: {
+        select: {
+          causeId: true,
+          causeName: true,
+          is501c3: true,
+          amount: true,
+        },
+      },
+    },
+  });
+
+  const allocations = new Map<string, AllocationDraft>();
+
+  for (const line of snapshotLines) {
+    const lineAdjustmentTotal = line.adjustments.reduce(
+      (sum, adjustment) => sum.add(adjustment.netContribAdj),
+      ZERO,
+    );
+
+    for (const allocation of line.causeAllocations) {
+      addAllocation(allocations, {
+        causeId: allocation.causeId,
+        causeName: allocation.causeName,
+        is501c3: allocation.is501c3,
+        allocated: computeAdjustedAllocationAmount({
+          baseAmount: allocation.amount,
+          lineNetContribution: line.netContribution,
+          lineAdjustmentTotal,
+        }),
+      });
+    }
+  }
+
+  const rows = Array.from(allocations.values()).map((allocation) => ({
+    shopId,
+    periodId: period.id,
+    causeId: allocation.causeId,
+    causeName: allocation.causeName,
+    is501c3: allocation.is501c3,
+    allocated: allocation.allocated,
+  }));
+
+  await db.causeAllocation.deleteMany({
+    where: {
+      shopId,
+      periodId: period.id,
+    },
+  });
+
+  if (rows.length > 0) {
+    await db.causeAllocation.createMany({ data: rows });
+  }
+
+  return rows;
+}
+
+export async function closeReportingPeriod(
+  shopId: string,
+  periodId: string,
+  db: DbClient = prisma,
+) {
+  return db.$transaction(async (tx) => {
+    const period = await tx.reportingPeriod.findFirst({
+      where: {
+        shopId,
+        id: periodId,
+      },
+    });
+
+    if (!period) {
+      throw new Error("Reporting period not found.");
+    }
+
+    if (period.status === "CLOSED") {
+      const allocations = await tx.causeAllocation.findMany({
+        where: {
+          shopId,
+          periodId,
+        },
+      });
+      return { closed: false, period, allocations };
+    }
+
+    const closingPeriod = await tx.reportingPeriod.update({
+      where: {
+        id: period.id,
+        shopId,
+      },
+      data: { status: "CLOSING" },
+    });
+
+    await tx.orderSnapshot.updateMany({
+      where: {
+        shopId,
+        createdAt: {
+          gte: closingPeriod.startDate,
+          lt: closingPeriod.endDate,
+        },
+      },
+      data: { periodId: closingPeriod.id },
+    });
+
+    const allocations = await materializeCauseAllocationsForPeriod(
+      shopId,
+      closingPeriod,
+      tx as DbClient,
+    );
+
+    const closedPeriod = await tx.reportingPeriod.update({
+      where: {
+        id: period.id,
+        shopId,
+      },
+      data: {
+        status: "CLOSED",
+        closedAt: new Date(),
+      },
+    });
+
+    await tx.auditLog.create({
+      data: {
+        shopId,
+        entity: "ReportingPeriod",
+        entityId: closedPeriod.id,
+        action: "REPORTING_PERIOD_CLOSED",
+        actor: "system",
+        payload: {
+          startDate: closedPeriod.startDate.toISOString(),
+          endDate: closedPeriod.endDate.toISOString(),
+          allocationCount: allocations.length,
+        },
+      },
+    });
+
+    return { closed: true, period: closedPeriod, allocations };
+  });
+}

--- a/prisma/migrations/20260407141946_phase4_reporting_period_lifecycle/migration.sql
+++ b/prisma/migrations/20260407141946_phase4_reporting_period_lifecycle/migration.sql
@@ -1,0 +1,144 @@
+-- AlterTable
+ALTER TABLE "OrderSnapshot" ADD COLUMN     "periodId" TEXT;
+
+-- CreateTable
+CREATE TABLE "ReportingPeriod" (
+    "id" TEXT NOT NULL,
+    "shopId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'OPEN',
+    "source" TEXT NOT NULL DEFAULT 'manual',
+    "startDate" TIMESTAMP(3) NOT NULL,
+    "endDate" TIMESTAMP(3) NOT NULL,
+    "shopifyPayoutId" TEXT,
+    "closedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ReportingPeriod_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CauseAllocation" (
+    "id" TEXT NOT NULL,
+    "shopId" TEXT NOT NULL,
+    "periodId" TEXT NOT NULL,
+    "causeId" TEXT NOT NULL,
+    "causeName" TEXT NOT NULL,
+    "is501c3" BOOLEAN NOT NULL,
+    "allocated" DECIMAL(10,4) NOT NULL,
+    "disbursed" DECIMAL(10,2) NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CauseAllocation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Disbursement" (
+    "id" TEXT NOT NULL,
+    "shopId" TEXT NOT NULL,
+    "periodId" TEXT NOT NULL,
+    "causeId" TEXT NOT NULL,
+    "amount" DECIMAL(10,2) NOT NULL,
+    "paidAt" TIMESTAMP(3) NOT NULL,
+    "paymentMethod" TEXT NOT NULL,
+    "referenceId" TEXT,
+    "receiptFileKey" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Disbursement_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TaxTrueUp" (
+    "id" TEXT NOT NULL,
+    "shopId" TEXT NOT NULL,
+    "periodId" TEXT NOT NULL,
+    "estimatedTax" DECIMAL(10,2) NOT NULL,
+    "actualTax" DECIMAL(10,2) NOT NULL,
+    "delta" DECIMAL(10,2) NOT NULL,
+    "redistributionNotes" TEXT,
+    "filedAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TaxTrueUp_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ShopifyChargeTransaction" (
+    "id" TEXT NOT NULL,
+    "shopId" TEXT NOT NULL,
+    "shopifyTransactionId" TEXT NOT NULL,
+    "periodId" TEXT,
+    "shopifyPayoutId" TEXT,
+    "transactionType" TEXT,
+    "description" TEXT,
+    "amount" DECIMAL(10,2) NOT NULL,
+    "currency" TEXT NOT NULL DEFAULT 'USD',
+    "processedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ShopifyChargeTransaction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ReportingPeriod_shopId_status_idx" ON "ReportingPeriod"("shopId", "status");
+
+-- CreateIndex
+CREATE INDEX "ReportingPeriod_shopId_startDate_endDate_idx" ON "ReportingPeriod"("shopId", "startDate", "endDate");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ReportingPeriod_shopId_shopifyPayoutId_key" ON "ReportingPeriod"("shopId", "shopifyPayoutId");
+
+-- CreateIndex
+CREATE INDEX "CauseAllocation_shopId_idx" ON "CauseAllocation"("shopId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CauseAllocation_periodId_causeId_key" ON "CauseAllocation"("periodId", "causeId");
+
+-- CreateIndex
+CREATE INDEX "Disbursement_shopId_idx" ON "Disbursement"("shopId");
+
+-- CreateIndex
+CREATE INDEX "Disbursement_periodId_causeId_idx" ON "Disbursement"("periodId", "causeId");
+
+-- CreateIndex
+CREATE INDEX "TaxTrueUp_shopId_idx" ON "TaxTrueUp"("shopId");
+
+-- CreateIndex
+CREATE INDEX "TaxTrueUp_periodId_idx" ON "TaxTrueUp"("periodId");
+
+-- CreateIndex
+CREATE INDEX "ShopifyChargeTransaction_shopId_idx" ON "ShopifyChargeTransaction"("shopId");
+
+-- CreateIndex
+CREATE INDEX "ShopifyChargeTransaction_shopId_shopifyPayoutId_idx" ON "ShopifyChargeTransaction"("shopId", "shopifyPayoutId");
+
+-- CreateIndex
+CREATE INDEX "ShopifyChargeTransaction_periodId_idx" ON "ShopifyChargeTransaction"("periodId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ShopifyChargeTransaction_shopId_shopifyTransactionId_key" ON "ShopifyChargeTransaction"("shopId", "shopifyTransactionId");
+
+-- CreateIndex
+CREATE INDEX "OrderSnapshot_shopId_periodId_idx" ON "OrderSnapshot"("shopId", "periodId");
+
+-- AddForeignKey
+ALTER TABLE "OrderSnapshot" ADD CONSTRAINT "OrderSnapshot_periodId_fkey" FOREIGN KEY ("periodId") REFERENCES "ReportingPeriod"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CauseAllocation" ADD CONSTRAINT "CauseAllocation_periodId_fkey" FOREIGN KEY ("periodId") REFERENCES "ReportingPeriod"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CauseAllocation" ADD CONSTRAINT "CauseAllocation_causeId_fkey" FOREIGN KEY ("causeId") REFERENCES "Cause"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Disbursement" ADD CONSTRAINT "Disbursement_periodId_fkey" FOREIGN KEY ("periodId") REFERENCES "ReportingPeriod"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Disbursement" ADD CONSTRAINT "Disbursement_causeId_fkey" FOREIGN KEY ("causeId") REFERENCES "Cause"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TaxTrueUp" ADD CONSTRAINT "TaxTrueUp_periodId_fkey" FOREIGN KEY ("periodId") REFERENCES "ReportingPeriod"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ShopifyChargeTransaction" ADD CONSTRAINT "ShopifyChargeTransaction_periodId_fkey" FOREIGN KEY ("periodId") REFERENCES "ReportingPeriod"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -288,6 +288,8 @@ model Cause {
 
   productAssignments ProductCauseAssignment[]
   lineAllocations    LineCauseAllocation[]
+  periodAllocations  CauseAllocation[]
+  disbursements      Disbursement[]
 
   @@index([shopId, status])
 }
@@ -314,12 +316,15 @@ model OrderSnapshot {
   shopifyOrderId String
   orderNumber    String?
   origin         String   @default("webhook")
+  periodId       String?
+  period         ReportingPeriod? @relation(fields: [periodId], references: [id], onDelete: SetNull)
   createdAt      DateTime @default(now())
 
   lines OrderSnapshotLine[]
 
   @@unique([shopId, shopifyOrderId])
   @@index([shopId])
+  @@index([shopId, periodId])
 }
 
 model OrderSnapshotLine {
@@ -410,6 +415,100 @@ model LineCauseAllocation {
   amount         Decimal           @db.Decimal(10, 4)
 
   @@index([shopId])
+}
+
+model ReportingPeriod {
+  id              String   @id @default(cuid())
+  shopId          String
+  status          String   @default("OPEN")
+  source          String   @default("manual")
+  startDate       DateTime
+  endDate         DateTime
+  shopifyPayoutId String?
+  closedAt        DateTime?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  snapshots        OrderSnapshot[]
+  causeAllocations CauseAllocation[]
+  disbursements    Disbursement[]
+  taxTrueUps        TaxTrueUp[]
+  shopifyCharges   ShopifyChargeTransaction[]
+
+  @@unique([shopId, shopifyPayoutId])
+  @@index([shopId, status])
+  @@index([shopId, startDate, endDate])
+}
+
+model CauseAllocation {
+  id            String          @id @default(cuid())
+  shopId        String
+  periodId      String
+  period        ReportingPeriod @relation(fields: [periodId], references: [id], onDelete: Cascade)
+  causeId       String
+  cause         Cause           @relation(fields: [causeId], references: [id], onDelete: Restrict)
+  causeName     String
+  is501c3       Boolean
+  allocated     Decimal         @db.Decimal(10, 4)
+  disbursed     Decimal         @default(0) @db.Decimal(10, 2)
+  createdAt     DateTime        @default(now())
+
+  @@unique([periodId, causeId])
+  @@index([shopId])
+}
+
+model Disbursement {
+  id             String          @id @default(cuid())
+  shopId         String
+  periodId       String
+  period         ReportingPeriod @relation(fields: [periodId], references: [id], onDelete: Cascade)
+  causeId        String
+  cause          Cause           @relation(fields: [causeId], references: [id], onDelete: Restrict)
+  amount         Decimal         @db.Decimal(10, 2)
+  paidAt         DateTime
+  paymentMethod  String
+  referenceId    String?
+  receiptFileKey String?
+  createdAt      DateTime        @default(now())
+
+  @@index([shopId])
+  @@index([periodId, causeId])
+}
+
+model TaxTrueUp {
+  id                  String          @id @default(cuid())
+  shopId              String
+  periodId            String
+  period              ReportingPeriod @relation(fields: [periodId], references: [id], onDelete: Cascade)
+  estimatedTax        Decimal         @db.Decimal(10, 2)
+  actualTax           Decimal         @db.Decimal(10, 2)
+  delta               Decimal         @db.Decimal(10, 2)
+  redistributionNotes String?
+  filedAt             DateTime
+  createdAt           DateTime        @default(now())
+
+  @@index([shopId])
+  @@index([periodId])
+}
+
+model ShopifyChargeTransaction {
+  id                   String           @id @default(cuid())
+  shopId               String
+  shopifyTransactionId String
+  periodId             String?
+  period               ReportingPeriod? @relation(fields: [periodId], references: [id], onDelete: SetNull)
+  shopifyPayoutId      String?
+  transactionType      String?
+  description          String?
+  amount               Decimal          @db.Decimal(10, 2)
+  currency             String           @default("USD")
+  processedAt          DateTime?
+  createdAt            DateTime         @default(now())
+
+  @@unique([shopId, shopifyTransactionId])
+  @@index([shopId])
+  @@index([shopId, shopifyPayoutId])
+  @@index([periodId])
 }
 
 model Adjustment {

--- a/shopify.app.phase3.toml
+++ b/shopify.app.phase3.toml
@@ -21,7 +21,7 @@ uri = "https://shopify.mnbecks.com/webhooks"
 
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
-scopes = "read_locales,read_metaobject_definitions,read_metaobjects,read_orders,read_products,write_app_proxy,write_metaobject_definitions,write_metaobjects,write_products"
+scopes = "read_locales,read_metaobject_definitions,read_metaobjects,read_orders,read_products,read_shopify_payments_payouts,write_app_proxy,write_metaobject_definitions,write_metaobjects,write_products"
 
 [auth]
 redirect_urls = [

--- a/shopify.app.phase3.toml
+++ b/shopify.app.phase3.toml
@@ -11,13 +11,15 @@ automatically_update_urls_on_dev = false
 [webhooks]
 api_version = "2026-04"
 
-[[webhooks.subscriptions]]
-topics = ["app/uninstalled", "products/update"]
-uri = "https://shopify.mnbecks.com/webhooks"
-
-[[webhooks.subscriptions]]
-topics = ["orders/create", "orders/updated", "refunds/create"]
-uri = "https://shopify.mnbecks.com/webhooks"
+  [[webhooks.subscriptions]]
+  topics = [
+  "products/update",
+  "orders/create",
+  "app/uninstalled",
+  "orders/updated",
+  "refunds/create"
+]
+  uri = "https://shopify.mnbecks.com/webhooks"
 
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
@@ -26,5 +28,5 @@ scopes = "read_locales,read_metaobject_definitions,read_metaobjects,read_orders,
 [auth]
 redirect_urls = [
   "https://shopify.mnbecks.com/auth/callback",
-  "https://shopify.mnbecks.com/auth/shopify/callback",
+  "https://shopify.mnbecks.com/auth/shopify/callback"
 ]

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -17,7 +17,7 @@ uri = "https://shopify.mnbecks.com/webhooks"
 
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
-scopes = "read_locales,read_metaobject_definitions,read_metaobjects,read_orders,read_products,write_app_proxy,write_metaobject_definitions,write_metaobjects,write_products"
+scopes = "read_locales,read_metaobject_definitions,read_metaobjects,read_orders,read_products,read_shopify_payments_payouts,write_app_proxy,write_metaobject_definitions,write_metaobjects,write_products"
 
 [auth]
 redirect_urls = [


### PR DESCRIPTION
## Summary

Starts Phase 4 by adding the reporting-period lifecycle foundation from #44 and the first Shopify Payments charge-sync backend slice from #45.

## What changed

- Added Phase 4 reporting schema for `ReportingPeriod`, `CauseAllocation`, `Disbursement`, `TaxTrueUp`, and `ShopifyChargeTransaction`.
- Added optional `OrderSnapshot.periodId` association for period locking/materialization.
- Added tenant guardrail coverage for the new reporting models.
- Added `reportingPeriodService.server.ts` with helpers to:
  - create/open payout-backed reporting periods idempotently
  - materialize cause allocations from immutable snapshot lines
  - close reporting periods through `OPEN` -> `CLOSING` -> `CLOSED`
- Added `ChargeSyncService` to sync Shopify Payments balance transactions with the `payments_transfer_id` query pattern.
- Added a daily `shopify-charges.daily` fan-out job and per-shop `shopify-charges.shop` worker.
- Added the correct `read_shopify_payments_payouts` access scope for payout/balance transaction API work.
- Added focused service and job processor tests.

## Validation

- `npx prisma validate`
- `npx prisma migrate dev --name phase4_reporting_period_lifecycle --skip-generate`
- `npx tsc --noEmit`
- `npm run lint`
- `npm test`
- `npm test -- --run app/services/chargeSyncService.server.test.ts app/jobs/processors.server.test.ts app/services/reportingPeriodService.server.test.ts`

## Notes

- Shopify's current webhook topic list does not support `payouts/create`, and deployment rejects that topic, so this PR does not subscribe to a payout webhook. Charge sync runs from the scheduled Shopify Payments API path instead.
- `npx prisma generate` still hit the known Windows Prisma query-engine DLL lock, but `npx prisma generate --no-engine` succeeded and TypeScript validated against the updated client.
- This intentionally does not implement the reporting dashboard, disbursements, true-ups, or exports. Those remain follow-up Phase 4 issues.
- The charge sync backend partially addresses #45, but I am not auto-closing it until charges are visible in reporting UI.

Closes #44
Partially addresses #45
