### PR TITLE
Add reporting period export downloads

### DIFF
--- a/app/routes/app.reporting-export.tsx
+++ b/app/routes/app.reporting-export.tsx
@@ -1,0 +1,43 @@
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { buildReportingPeriodCsv, buildReportingPeriodPdf } from "../services/reportingExport.server";
+import { buildReportingSummary } from "../services/reportingSummary.server";
+import { authenticateAdminRequest } from "../utils/admin-auth.server";
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const { session } = await authenticateAdminRequest(request);
+  const shopId = session.shop;
+  const url = new URL(request.url);
+  const requestedPeriodId = url.searchParams.get("periodId") ?? "";
+  const format = url.searchParams.get("format");
+
+  if (format !== "csv" && format !== "pdf") {
+    return new Response("Export format must be csv or pdf.", { status: 400 });
+  }
+
+  const result = await buildReportingSummary(shopId, requestedPeriodId);
+  if (!result.summary) {
+    return new Response("Reporting period not found.", { status: 404 });
+  }
+
+  const start = result.summary.period.startDate.slice(0, 10);
+  const end = result.summary.period.endDate.slice(0, 10);
+  const filename = `reporting-period-${start}-to-${end}.${format}`;
+
+  if (format === "csv") {
+    return new Response(buildReportingPeriodCsv(result.summary), {
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+        "Cache-Control": "no-store",
+      },
+    });
+  }
+
+  return new Response(buildReportingPeriodPdf(result.summary), {
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+      "Cache-Control": "no-store",
+    },
+  });
+};

--- a/app/routes/app.reporting.tsx
+++ b/app/routes/app.reporting.tsx
@@ -3,7 +3,6 @@ import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { useFetcher, useLoaderData, useRouteError, useSearchParams } from "@remix-run/react";
 import { Prisma } from "@prisma/client";
 import { z } from "zod";
-import { prisma } from "../db.server";
 import {
   ACCEPTED_RECEIPT_CONTENT_TYPES,
   DisbursementError,
@@ -11,22 +10,18 @@ import {
   logDisbursement,
   MAX_RECEIPT_BYTES,
 } from "../services/disbursementService.server";
-import { listOutstandingCauseAllocations } from "../services/causePayables.server";
 import { closeReportingPeriod } from "../services/reportingPeriodService.server";
-import { createReceiptStorage } from "../services/receiptStorage.server";
+import { buildReportingSummary } from "../services/reportingSummary.server";
 import {
-  calculateEstimatedTaxForPeriod,
   recordTaxTrueUp,
   TaxTrueUpError,
   taxTrueUpErrorCodes,
 } from "../services/taxTrueUpService.server";
-import { normalizeTaxDeductionMode } from "../services/taxReserve.server";
 import { authenticateAdminRequest } from "../utils/admin-auth.server";
 import { parseOptionalNonNegativeMoney } from "../utils/money-parsing";
 import { useAppLocalization } from "../utils/use-app-localization";
 
 const ZERO = new Prisma.Decimal(0);
-const ADJUSTMENT_RATIO_GUARD = new Prisma.Decimal(10);
 
 function floorCurrency(value: string) {
   return new Prisma.Decimal(value).toDecimalPlaces(2, Prisma.Decimal.ROUND_FLOOR).toString();
@@ -138,17 +133,6 @@ type TaxTrueUpRow = {
   }>;
 };
 
-type TaxTrueUpCarryForwardRow = {
-  id: string;
-  periodId: string;
-  delta: string;
-  redistributions: Array<{
-    causeId: string;
-    causeName: string;
-    amount: string;
-  }>;
-};
-
 const disbursementSchema = z.object({
   periodId: z.string().trim().cuid("Reporting period id is invalid."),
   causeId: z.string().trim().cuid("Cause id is invalid."),
@@ -190,539 +174,12 @@ const taxTrueUpSchema = z.object({
   confirmShortfall: z.string().trim().optional(),
 });
 
-function addAllocation(
-  allocations: Map<string, { causeId: string; causeName: string; is501c3: boolean; allocated: Prisma.Decimal }>,
-  allocation: { causeId: string; causeName: string; is501c3: boolean; allocated: Prisma.Decimal },
-) {
-  const current = allocations.get(allocation.causeId);
-  if (!current) {
-    allocations.set(allocation.causeId, allocation);
-    return;
-  }
-
-  allocations.set(allocation.causeId, {
-    ...current,
-    allocated: current.allocated.add(allocation.allocated),
-  });
-}
-
-function computeAdjustedAllocationAmount({
-  baseAmount,
-  lineNetContribution,
-  lineAdjustmentTotal,
-}: {
-  baseAmount: Prisma.Decimal;
-  lineNetContribution: Prisma.Decimal;
-  lineAdjustmentTotal: Prisma.Decimal;
-}) {
-  if (lineNetContribution.equals(0) || lineAdjustmentTotal.equals(0)) {
-    return baseAmount;
-  }
-
-  const ratio = lineAdjustmentTotal.div(lineNetContribution);
-  if (ratio.abs().greaterThan(ADJUSTMENT_RATIO_GUARD)) {
-    return baseAmount;
-  }
-
-  return baseAmount.add(baseAmount.mul(ratio));
-}
-
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticateAdminRequest(request);
   const shopId = session.shop;
   const url = new URL(request.url);
   const requestedPeriodId = url.searchParams.get("periodId") ?? "";
-
-  const periods = await prisma.reportingPeriod.findMany({
-    where: { shopId },
-    orderBy: [{ startDate: "desc" }, { createdAt: "desc" }],
-    select: {
-      id: true,
-      status: true,
-      source: true,
-      startDate: true,
-      endDate: true,
-      shopifyPayoutId: true,
-      closedAt: true,
-    },
-  });
-
-  if (periods.length === 0) {
-    return Response.json({
-      periods: [],
-      selectedPeriodId: null,
-      summary: null,
-    });
-  }
-
-  const selectedPeriod = periods.find((period) => period.id === requestedPeriodId) ?? periods[0];
-
-  const [shop, snapshotLines, closedAllocations, expensesSummary, chargesSummary, charges, disbursements, taxTrueUps, carryForwardTrueUps, activeCauses, outstandingAllocations] =
-    await Promise.all([
-      prisma.shop.findUnique({
-        where: { shopId },
-        select: {
-          effectiveTaxRate: true,
-          taxDeductionMode: true,
-        },
-      }),
-      prisma.orderSnapshotLine.findMany({
-        where: {
-          shopId,
-          snapshot: {
-            createdAt: {
-              gte: selectedPeriod.startDate,
-              lt: selectedPeriod.endDate,
-            },
-          },
-        },
-        select: {
-          netContribution: true,
-          adjustments: { select: { netContribAdj: true } },
-          causeAllocations: {
-            select: { causeId: true, causeName: true, is501c3: true, amount: true },
-          },
-        },
-      }),
-      prisma.causeAllocation.findMany({
-        where: {
-          shopId,
-          periodId: selectedPeriod.id,
-        },
-        select: {
-          causeId: true,
-          causeName: true,
-          is501c3: true,
-          allocated: true,
-          disbursed: true,
-        },
-      }),
-      prisma.businessExpense.aggregate({
-        where: {
-          shopId,
-          expenseDate: {
-            gte: selectedPeriod.startDate,
-            lt: selectedPeriod.endDate,
-          },
-        },
-        _sum: { amount: true },
-      }),
-      prisma.shopifyChargeTransaction.aggregate({
-        where: {
-          shopId,
-          OR: [
-            { periodId: selectedPeriod.id },
-            {
-              periodId: null,
-              processedAt: {
-                gte: selectedPeriod.startDate,
-                lt: selectedPeriod.endDate,
-              },
-            },
-          ],
-        },
-        _sum: { amount: true },
-      }),
-      prisma.shopifyChargeTransaction.findMany({
-        where: {
-          shopId,
-          OR: [
-            { periodId: selectedPeriod.id },
-            {
-              periodId: null,
-              processedAt: {
-                gte: selectedPeriod.startDate,
-                lt: selectedPeriod.endDate,
-              },
-            },
-          ],
-        },
-        orderBy: [{ processedAt: "desc" }, { createdAt: "desc" }],
-        take: 15,
-        select: {
-          id: true,
-          description: true,
-          amount: true,
-          processedAt: true,
-        },
-      }),
-      prisma.disbursement.findMany({
-        where: {
-          shopId,
-          periodId: selectedPeriod.id,
-        },
-        orderBy: [{ paidAt: "desc" }, { createdAt: "desc" }],
-        select: {
-          id: true,
-          causeId: true,
-          amount: true,
-          allocatedAmount: true,
-          extraContributionAmount: true,
-          feesCoveredAmount: true,
-          paidAt: true,
-          paymentMethod: true,
-          referenceId: true,
-          receiptFileKey: true,
-          cause: {
-            select: {
-              name: true,
-            },
-          },
-          applications: {
-            select: {
-              amount: true,
-              causeAllocation: {
-                select: {
-                  periodId: true,
-                  period: {
-                    select: {
-                      startDate: true,
-                      endDate: true,
-                    },
-                  },
-                },
-              },
-            },
-            orderBy: {
-              causeAllocation: {
-                period: {
-                  endDate: "asc",
-                },
-              },
-            },
-          },
-        },
-      }),
-      prisma.taxTrueUp.findMany({
-        where: {
-          shopId,
-          periodId: selectedPeriod.id,
-        },
-        orderBy: [{ filedAt: "desc" }, { createdAt: "desc" }],
-        select: {
-          id: true,
-          estimatedTax: true,
-          actualTax: true,
-          delta: true,
-          filedAt: true,
-          redistributionNotes: true,
-          appliedPeriodId: true,
-          redistributions: {
-            select: {
-              causeId: true,
-              causeName: true,
-              amount: true,
-            },
-          },
-        },
-      }),
-      prisma.taxTrueUp.findMany({
-        where: {
-          shopId,
-          appliedPeriodId: selectedPeriod.id,
-        },
-        select: {
-          id: true,
-          periodId: true,
-          delta: true,
-          redistributions: {
-            select: {
-              causeId: true,
-              causeName: true,
-              amount: true,
-            },
-          },
-        },
-      }),
-      prisma.cause.findMany({
-        where: {
-          shopId,
-          status: "active",
-        },
-        orderBy: { name: "asc" },
-        select: {
-          id: true,
-          name: true,
-        },
-      }),
-      listOutstandingCauseAllocations(
-        shopId,
-        {
-          throughPeriodEndDate: selectedPeriod.endDate,
-        },
-        prisma,
-      ),
-    ]);
-
-  const allocationMap = new Map<string, { causeId: string; causeName: string; is501c3: boolean; allocated: Prisma.Decimal }>();
-  let totalNetContribution = ZERO;
-
-  for (const line of snapshotLines) {
-    const adjustmentTotal = line.adjustments.reduce((sum, adj) => sum.add(adj.netContribAdj), ZERO);
-    totalNetContribution = totalNetContribution.add(line.netContribution).add(adjustmentTotal);
-
-    for (const allocation of line.causeAllocations) {
-      const adjusted = computeAdjustedAllocationAmount({
-        baseAmount: allocation.amount,
-        lineNetContribution: line.netContribution,
-        lineAdjustmentTotal: adjustmentTotal,
-      });
-
-      addAllocation(allocationMap, {
-        causeId: allocation.causeId,
-        causeName: allocation.causeName,
-        is501c3: allocation.is501c3,
-        allocated: adjusted,
-      });
-    }
-  }
-
-  const expenseTotal = expensesSummary._sum.amount ?? ZERO;
-  const shopifyCharges = chargesSummary._sum.amount ?? ZERO;
-  const useClosedAllocations = selectedPeriod.status === "CLOSED" && closedAllocations.length > 0;
-  let allocationRows = useClosedAllocations
-    ? closedAllocations.map((allocation) => ({
-        causeId: allocation.causeId,
-        causeName: allocation.causeName,
-        is501c3: allocation.is501c3,
-        allocated: allocation.allocated,
-        disbursed: allocation.disbursed,
-      }))
-    : Array.from(allocationMap.values()).map((allocation) => ({
-        causeId: allocation.causeId,
-        causeName: allocation.causeName,
-        is501c3: allocation.is501c3,
-        allocated: allocation.allocated,
-        disbursed: ZERO,
-      }));
-
-  if (carryForwardTrueUps.length > 0) {
-    const allocationMapWithCarryForward = new Map(
-      allocationRows.map((allocation) => [
-        allocation.causeId,
-        {
-          ...allocation,
-        },
-      ]),
-    );
-
-    for (const trueUp of carryForwardTrueUps) {
-      for (const redistribution of trueUp.redistributions) {
-        const existing = allocationMapWithCarryForward.get(redistribution.causeId);
-        if (existing) {
-          existing.allocated = existing.allocated.add(redistribution.amount);
-          continue;
-        }
-
-        allocationMapWithCarryForward.set(redistribution.causeId, {
-          causeId: redistribution.causeId,
-          causeName: redistribution.causeName,
-          is501c3: false,
-          allocated: redistribution.amount,
-          disbursed: ZERO,
-        });
-      }
-    }
-
-    allocationRows = Array.from(allocationMapWithCarryForward.values());
-  }
-
-  const allocation501c3Total = allocationRows.reduce(
-    (sum, allocation) => (allocation.is501c3 ? sum.add(allocation.allocated) : sum),
-    ZERO,
-  );
-
-  const deductionPool = expenseTotal.add(allocation501c3Total);
-  const taxableExposure = totalNetContribution.sub(deductionPool);
-  const widgetTaxSuppressed = taxableExposure.lessThanOrEqualTo(0);
-  const taxEstimate = await calculateEstimatedTaxForPeriod(shopId, selectedPeriod.id, prisma);
-  const carryForwardSurplus = carryForwardTrueUps.reduce(
-    (sum, trueUp) => (trueUp.delta.greaterThan(ZERO) ? sum.add(trueUp.delta) : sum),
-    ZERO,
-  );
-  const carryForwardShortfall = carryForwardTrueUps.reduce(
-    (sum, trueUp) => (trueUp.delta.lessThan(ZERO) ? sum.add(trueUp.delta.abs()) : sum),
-    ZERO,
-  );
-  const receiptStorage = createReceiptStorage();
-  const disbursementRows = await Promise.all(
-    disbursements.map(async (disbursement) => ({
-      id: disbursement.id,
-      causeId: disbursement.causeId,
-      causeName: disbursement.cause.name,
-      amount: disbursement.amount.toString(),
-      allocatedAmount: disbursement.allocatedAmount.toString(),
-      extraContributionAmount: disbursement.extraContributionAmount.toString(),
-      feesCoveredAmount: disbursement.feesCoveredAmount.toString(),
-      paidAt: disbursement.paidAt.toISOString(),
-      paymentMethod: disbursement.paymentMethod,
-      referenceId: disbursement.referenceId ?? null,
-      receiptUrl: disbursement.receiptFileKey
-        ? await receiptStorage.getSignedReadUrl({
-            key: disbursement.receiptFileKey,
-            expiresInSeconds: 60 * 60,
-          })
-        : null,
-      applications: disbursement.applications.map((application) => ({
-        periodId: application.causeAllocation.periodId,
-        periodStartDate: application.causeAllocation.period.startDate.toISOString(),
-        periodEndDate: application.causeAllocation.period.endDate.toISOString(),
-        amount: application.amount.toString(),
-      })),
-    })),
-  );
-
-  const causePayablesMap = new Map<
-    string,
-    {
-      causeId: string;
-      causeName: string;
-      is501c3: boolean;
-      currentOutstanding: Prisma.Decimal;
-      priorOutstanding: Prisma.Decimal;
-      periods: CausePayablePeriodRow[];
-    }
-  >();
-
-  for (const allocation of outstandingAllocations) {
-    const existing = causePayablesMap.get(allocation.causeId) ?? {
-      causeId: allocation.causeId,
-      causeName: allocation.causeName,
-      is501c3: allocation.is501c3,
-      currentOutstanding: ZERO,
-      priorOutstanding: ZERO,
-      periods: [],
-    };
-
-    if (allocation.periodId === selectedPeriod.id) {
-      existing.currentOutstanding = existing.currentOutstanding.add(allocation.remaining);
-    } else {
-      existing.priorOutstanding = existing.priorOutstanding.add(allocation.remaining);
-    }
-
-    existing.periods.push({
-      periodId: allocation.periodId,
-      periodStartDate: allocation.periodStartDate.toISOString(),
-      periodEndDate: allocation.periodEndDate.toISOString(),
-      amount: allocation.remaining.toString(),
-    });
-    causePayablesMap.set(allocation.causeId, existing);
-  }
-
-  if (selectedPeriod.status === "OPEN") {
-    for (const allocation of allocationRows) {
-      const existing = causePayablesMap.get(allocation.causeId) ?? {
-        causeId: allocation.causeId,
-        causeName: allocation.causeName,
-        is501c3: allocation.is501c3,
-        currentOutstanding: ZERO,
-        priorOutstanding: ZERO,
-        periods: [],
-      };
-
-      existing.currentOutstanding = existing.currentOutstanding.add(new Prisma.Decimal(allocation.allocated));
-      causePayablesMap.set(allocation.causeId, existing);
-    }
-  }
-
-  const causePayables = Array.from(causePayablesMap.values()).map<CausePayableRow>((payable) => {
-    const totalOutstanding = payable.currentOutstanding.add(payable.priorOutstanding);
-    return {
-      causeId: payable.causeId,
-      causeName: payable.causeName,
-      is501c3: payable.is501c3,
-      currentOutstanding: payable.currentOutstanding.toString(),
-      priorOutstanding: payable.priorOutstanding.toString(),
-      totalOutstanding: totalOutstanding.toString(),
-      overdue: payable.priorOutstanding.greaterThan(ZERO),
-      periods: payable.periods,
-    };
-  });
-
-  return Response.json({
-    periods: periods.map<PeriodRow>((period) => ({
-      id: period.id,
-      status: period.status,
-      source: period.source,
-      startDate: period.startDate.toISOString(),
-      endDate: period.endDate.toISOString(),
-      shopifyPayoutId: period.shopifyPayoutId ?? null,
-      closedAt: period.closedAt?.toISOString() ?? null,
-    })),
-    selectedPeriodId: selectedPeriod.id,
-    summary: {
-      period: {
-        id: selectedPeriod.id,
-        status: selectedPeriod.status,
-        startDate: selectedPeriod.startDate.toISOString(),
-        endDate: selectedPeriod.endDate.toISOString(),
-        shopifyPayoutId: selectedPeriod.shopifyPayoutId ?? null,
-        closedAt: selectedPeriod.closedAt?.toISOString() ?? null,
-      },
-      track1: {
-        totalNetContribution: totalNetContribution.toString(),
-        shopifyCharges: shopifyCharges.toString(),
-        donationPool: totalNetContribution.sub(shopifyCharges).add(carryForwardSurplus).sub(carryForwardShortfall).toString(),
-        taxTrueUpSurplusApplied: carryForwardSurplus.toString(),
-        taxTrueUpShortfallApplied: carryForwardShortfall.toString(),
-        allocations: allocationRows.map((allocation) => ({
-          causeId: allocation.causeId,
-          causeName: allocation.causeName,
-          is501c3: allocation.is501c3,
-          allocated: allocation.allocated.toString(),
-          disbursed: allocation.disbursed.toString(),
-        })),
-      },
-      track2: {
-        deductionPool: deductionPool.toString(),
-        taxableExposure: taxableExposure.toString(),
-        widgetTaxSuppressed,
-        taxableBase: taxEstimate.taxableBase.toString(),
-        taxableWeight: taxEstimate.taxableWeight.toString(),
-        estimatedTaxReserve: taxEstimate.estimatedTaxReserve.toString(),
-        effectiveTaxRate: shop?.effectiveTaxRate?.toString() ?? null,
-        taxDeductionMode: normalizeTaxDeductionMode(shop?.taxDeductionMode),
-        businessExpenseTotal: expenseTotal.toString(),
-        allocation501c3Total: allocation501c3Total.toString(),
-      },
-      charges: charges.map<ChargeRow>((charge) => ({
-        id: charge.id,
-        description: charge.description ?? "Shopify charge",
-        amount: charge.amount.toString(),
-        processedAt: charge.processedAt?.toISOString() ?? null,
-      })),
-      disbursements: disbursementRows,
-      causePayables,
-      taxTrueUps: taxTrueUps.map<TaxTrueUpRow>((trueUp) => ({
-        id: trueUp.id,
-        estimatedTax: trueUp.estimatedTax.toString(),
-        actualTax: trueUp.actualTax.toString(),
-        delta: trueUp.delta.toString(),
-        filedAt: trueUp.filedAt.toISOString(),
-        redistributionNotes: trueUp.redistributionNotes ?? null,
-        appliedPeriodId: trueUp.appliedPeriodId ?? null,
-        redistributions: trueUp.redistributions.map((redistribution) => ({
-          causeId: redistribution.causeId,
-          causeName: redistribution.causeName,
-          amount: redistribution.amount.toString(),
-        })),
-      })),
-      carryForwardTrueUps: carryForwardTrueUps.map<TaxTrueUpCarryForwardRow>((trueUp) => ({
-        id: trueUp.id,
-        periodId: trueUp.periodId,
-        delta: trueUp.delta.toString(),
-        redistributions: trueUp.redistributions.map((redistribution) => ({
-          causeId: redistribution.causeId,
-          causeName: redistribution.causeName,
-          amount: redistribution.amount.toString(),
-        })),
-      })),
-      activeCauses: activeCauses.map((cause) => ({
-        id: cause.id,
-        name: cause.name,
-      })),
-    },
-  });
+  return Response.json(await buildReportingSummary(shopId, requestedPeriodId));
 };
 
 export const action = async ({ request }: ActionFunctionArgs) => {
@@ -940,6 +397,7 @@ export default function ReportingPage() {
   const disbursementFormRef = useRef<HTMLFormElement>(null);
   const trueUpFormRef = useRef<HTMLFormElement>(null);
   const [closeDialogOpen, setCloseDialogOpen] = useState(false);
+  const [exportingFormat, setExportingFormat] = useState<"csv" | "pdf" | null>(null);
 
   useEffect(() => {
     const dialog = closeDialogRef.current;
@@ -962,6 +420,12 @@ export default function ReportingPage() {
       trueUpFormRef.current?.reset();
     }
   }, [trueUpFetcher.data]);
+
+  useEffect(() => {
+    if (!exportingFormat) return;
+    const timeout = window.setTimeout(() => setExportingFormat(null), 2000);
+    return () => window.clearTimeout(timeout);
+  }, [exportingFormat]);
 
   const selectedPeriod = summary?.period ?? null;
   const statusMessage = closeFetcher.data?.message ?? disbursementFetcher.data?.message ?? trueUpFetcher.data?.message ?? "";
@@ -1180,6 +644,34 @@ export default function ReportingPage() {
               <s-text color="subdued">
                 {formatDateRange(selectedPeriod.startDate, selectedPeriod.endDate, locale)} · {selectedPeriod.status}
               </s-text>
+            ) : null}
+            {selectedPeriod ? (
+              <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
+                <form method="get" action="/app/reporting-export" target="_blank">
+                  <input type="hidden" name="periodId" value={selectedPeriod.id} />
+                  <input type="hidden" name="format" value="csv" />
+                  <button
+                    type="submit"
+                    aria-label="Export reporting period as CSV"
+                    onClick={() => setExportingFormat("csv")}
+                    style={disbursementSubmitStyle}
+                  >
+                    {exportingFormat === "csv" ? "Exporting CSV..." : "Export CSV"}
+                  </button>
+                </form>
+                <form method="get" action="/app/reporting-export" target="_blank">
+                  <input type="hidden" name="periodId" value={selectedPeriod.id} />
+                  <input type="hidden" name="format" value="pdf" />
+                  <button
+                    type="submit"
+                    aria-label="Export reporting period as PDF"
+                    onClick={() => setExportingFormat("pdf")}
+                    style={disbursementSubmitStyle}
+                  >
+                    {exportingFormat === "pdf" ? "Exporting PDF..." : "Export PDF"}
+                  </button>
+                </form>
+              </div>
             ) : null}
           </div>
         </s-section>

--- a/app/routes/app.reporting.tsx
+++ b/app/routes/app.reporting.tsx
@@ -398,6 +398,7 @@ export default function ReportingPage() {
   const trueUpFormRef = useRef<HTMLFormElement>(null);
   const [closeDialogOpen, setCloseDialogOpen] = useState(false);
   const [exportingFormat, setExportingFormat] = useState<"csv" | "pdf" | null>(null);
+  const [exportError, setExportError] = useState("");
 
   useEffect(() => {
     const dialog = closeDialogRef.current;
@@ -455,6 +456,43 @@ export default function ReportingPage() {
     fd.append("periodId", selectedPeriod.id);
     closeFetcher.submit(fd, { method: "post" });
     setCloseDialogOpen(false);
+  }
+
+  async function exportPeriod(format: "csv" | "pdf") {
+    if (!selectedPeriod) return;
+    setExportError("");
+    setExportingFormat(format);
+    try {
+      const params = new URLSearchParams(searchParams);
+      params.set("periodId", selectedPeriod.id);
+      params.set("format", format);
+
+      const response = await fetch(`/app/reporting-export?${params.toString()}`, {
+        credentials: "same-origin",
+      });
+
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || `Unable to export ${format.toUpperCase()}.`);
+      }
+
+      const blob = await response.blob();
+      const disposition = response.headers.get("content-disposition") ?? "";
+      const match = disposition.match(/filename="([^"]+)"/);
+      const filename = match?.[1] ?? `reporting-period.${format}`;
+      const objectUrl = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = objectUrl;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(objectUrl);
+    } catch (error) {
+      setExportError(error instanceof Error ? error.message : `Unable to export ${format.toUpperCase()}.`);
+    } finally {
+      setExportingFormat(null);
+    }
   }
 
   const allocationRows: AllocationRow[] = summary
@@ -614,6 +652,11 @@ export default function ReportingPage() {
             <s-text>{trueUpFetcher.data.message}</s-text>
           </s-banner>
         )}
+        {exportError ? (
+          <s-banner tone="critical">
+            <s-text>{exportError}</s-text>
+          </s-banner>
+        ) : null}
 
         <s-section>
           <div style={{ display: "grid", gap: "0.5rem" }}>
@@ -647,30 +690,24 @@ export default function ReportingPage() {
             ) : null}
             {selectedPeriod ? (
               <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
-                <form method="get" action="/app/reporting-export" target="_blank">
-                  <input type="hidden" name="periodId" value={selectedPeriod.id} />
-                  <input type="hidden" name="format" value="csv" />
-                  <button
-                    type="submit"
-                    aria-label="Export reporting period as CSV"
-                    onClick={() => setExportingFormat("csv")}
-                    style={disbursementSubmitStyle}
-                  >
-                    {exportingFormat === "csv" ? "Exporting CSV..." : "Export CSV"}
-                  </button>
-                </form>
-                <form method="get" action="/app/reporting-export" target="_blank">
-                  <input type="hidden" name="periodId" value={selectedPeriod.id} />
-                  <input type="hidden" name="format" value="pdf" />
-                  <button
-                    type="submit"
-                    aria-label="Export reporting period as PDF"
-                    onClick={() => setExportingFormat("pdf")}
-                    style={disbursementSubmitStyle}
-                  >
-                    {exportingFormat === "pdf" ? "Exporting PDF..." : "Export PDF"}
-                  </button>
-                </form>
+                <button
+                  type="button"
+                  aria-label="Export reporting period as CSV"
+                  onClick={() => void exportPeriod("csv")}
+                  disabled={exportingFormat !== null}
+                  style={disbursementSubmitStyle}
+                >
+                  {exportingFormat === "csv" ? "Exporting CSV..." : "Export CSV"}
+                </button>
+                <button
+                  type="button"
+                  aria-label="Export reporting period as PDF"
+                  onClick={() => void exportPeriod("pdf")}
+                  disabled={exportingFormat !== null}
+                  style={disbursementSubmitStyle}
+                >
+                  {exportingFormat === "pdf" ? "Exporting PDF..." : "Export PDF"}
+                </button>
               </div>
             ) : null}
           </div>

--- a/app/routes/ui-fixtures.reporting-bootstrap.tsx
+++ b/app/routes/ui-fixtures.reporting-bootstrap.tsx
@@ -206,6 +206,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
   return Response.json({
     shopId,
+    closedPeriodId: closedPeriod.id,
     reportingUrl: `${baseUrl}/app/reporting?__playwrightShop=${encodeURIComponent(shopId)}&periodId=${encodeURIComponent(period.id)}`,
     closedReportingUrl: `${baseUrl}/app/reporting?__playwrightShop=${encodeURIComponent(shopId)}&periodId=${encodeURIComponent(closedPeriod.id)}`,
   });

--- a/app/services/reportingExport.server.test.ts
+++ b/app/services/reportingExport.server.test.ts
@@ -100,21 +100,58 @@ const summary: NonNullable<ReportingSummaryResult["summary"]> = {
 };
 
 describe("reporting exports", () => {
-  it("builds csv output with key reporting sections", () => {
+  it("builds csv output as a single tabular dataset", () => {
     const csv = buildReportingPeriodCsv(summary);
+    const [headerLine, ...rowLines] = csv.split("\n");
+    const headers = headerLine.split(",");
 
-    expect(csv).toContain("Track 1");
-    expect(csv).toContain("Outstanding cause payables");
+    expect(headers).toEqual([
+      "section",
+      "recordType",
+      "periodId",
+      "periodStartDate",
+      "periodEndDate",
+      "status",
+      "causeId",
+      "causeName",
+      "is501c3",
+      "description",
+      "paidAt",
+      "filedAt",
+      "processedAt",
+      "paymentMethod",
+      "referenceId",
+      "shopifyPayoutId",
+      "metric",
+      "value",
+      "allocatedAmount",
+      "disbursedAmount",
+      "remainingAmount",
+      "currentOutstanding",
+      "priorOutstanding",
+      "totalOutstanding",
+      "extraContributionAmount",
+      "feesCoveredAmount",
+      "delta",
+      "notes",
+      "applicationPeriods",
+      "redistributions",
+    ]);
+    expect(rowLines.every((line) => line.split(",").length >= headers.length)).toBe(true);
+    expect(csv).toContain("track1,metric");
+    expect(csv).toContain("payables,causePayable");
     expect(csv).toContain("Playwright Cause");
     expect(csv).toContain("fixture-ach-001");
     expect(csv).toContain("2026-01-31..2026-02-14=20.00");
   });
 
-  it("builds a pdf file payload", () => {
+  it("builds a pdf file payload with a safe top margin", () => {
     const pdf = buildReportingPeriodPdf(summary);
+    const pdfText = Buffer.from(pdf).toString("utf8");
 
     expect(Buffer.from(pdf).subarray(0, 8).toString("utf8")).toContain("%PDF-1.4");
-    expect(Buffer.from(pdf).toString("utf8")).toContain("Reporting period:");
-    expect(Buffer.from(pdf).toString("utf8")).toContain("Outstanding cause payables");
+    expect(pdfText).toContain("Reporting period:");
+    expect(pdfText).toContain("Outstanding cause payables");
+    expect(pdfText).toContain("50 756 Td");
   });
 });

--- a/app/services/reportingExport.server.test.ts
+++ b/app/services/reportingExport.server.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { buildReportingPeriodCsv, buildReportingPeriodPdf } from "./reportingExport.server";
+import type { ReportingSummaryResult } from "./reportingSummary.server";
+
+const summary: NonNullable<ReportingSummaryResult["summary"]> = {
+  period: {
+    id: "period-1",
+    status: "CLOSED",
+    startDate: "2026-03-01T00:00:00.000Z",
+    endDate: "2026-03-15T00:00:00.000Z",
+    shopifyPayoutId: "payout_fixture_001",
+    closedAt: "2026-03-16T00:00:00.000Z",
+  },
+  track1: {
+    totalNetContribution: "90.00",
+    shopifyCharges: "12.00",
+    donationPool: "78.00",
+    taxTrueUpSurplusApplied: "0.00",
+    taxTrueUpShortfallApplied: "0.00",
+    allocations: [
+      {
+        causeId: "cause-1",
+        causeName: "Playwright Cause",
+        is501c3: true,
+        allocated: "54.00",
+        disbursed: "20.00",
+      },
+    ],
+  },
+  track2: {
+    deductionPool: "74.00",
+    taxableExposure: "16.00",
+    widgetTaxSuppressed: false,
+    taxableBase: "16.00",
+    taxableWeight: "1.00",
+    estimatedTaxReserve: "4.00",
+    effectiveTaxRate: "0.2500",
+    taxDeductionMode: "all_causes",
+    businessExpenseTotal: "20.00",
+    allocation501c3Total: "54.00",
+  },
+  charges: [
+    {
+      id: "charge-1",
+      description: "Shopify charge A",
+      amount: "12.00",
+      processedAt: "2026-03-07T00:00:00.000Z",
+    },
+  ],
+  disbursements: [
+    {
+      id: "dis-1",
+      causeId: "cause-1",
+      causeName: "Playwright Cause",
+      amount: "27.00",
+      allocatedAmount: "20.00",
+      extraContributionAmount: "5.00",
+      feesCoveredAmount: "2.00",
+      paidAt: "2026-03-09T00:00:00.000Z",
+      paymentMethod: "ACH",
+      referenceId: "fixture-ach-001",
+      receiptUrl: null,
+      applications: [
+        {
+          periodId: "period-old",
+          periodStartDate: "2026-01-31T00:00:00.000Z",
+          periodEndDate: "2026-02-14T00:00:00.000Z",
+          amount: "20.00",
+        },
+      ],
+    },
+  ],
+  causePayables: [
+    {
+      causeId: "cause-1",
+      causeName: "Playwright Cause",
+      is501c3: true,
+      currentOutstanding: "54.00",
+      priorOutstanding: "20.00",
+      totalOutstanding: "74.00",
+      overdue: true,
+      periods: [
+        {
+          periodId: "period-old",
+          periodStartDate: "2026-01-31T00:00:00.000Z",
+          periodEndDate: "2026-02-14T00:00:00.000Z",
+          amount: "20.00",
+        },
+      ],
+    },
+  ],
+  taxTrueUps: [],
+  carryForwardTrueUps: [],
+  activeCauses: [
+    {
+      id: "cause-1",
+      name: "Playwright Cause",
+    },
+  ],
+};
+
+describe("reporting exports", () => {
+  it("builds csv output with key reporting sections", () => {
+    const csv = buildReportingPeriodCsv(summary);
+
+    expect(csv).toContain("Track 1");
+    expect(csv).toContain("Outstanding cause payables");
+    expect(csv).toContain("Playwright Cause");
+    expect(csv).toContain("fixture-ach-001");
+    expect(csv).toContain("2026-01-31..2026-02-14=20.00");
+  });
+
+  it("builds a pdf file payload", () => {
+    const pdf = buildReportingPeriodPdf(summary);
+
+    expect(Buffer.from(pdf).subarray(0, 8).toString("utf8")).toContain("%PDF-1.4");
+    expect(Buffer.from(pdf).toString("utf8")).toContain("Reporting period:");
+    expect(Buffer.from(pdf).toString("utf8")).toContain("Outstanding cause payables");
+  });
+});

--- a/app/services/reportingExport.server.ts
+++ b/app/services/reportingExport.server.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import { Prisma } from "@prisma/client";
 import type { ReportingSummaryResult } from "./reportingSummary.server";
 
 function csvEscape(value: string) {
@@ -8,94 +9,256 @@ function csvEscape(value: string) {
   return value;
 }
 
+type CsvRow = Record<string, string>;
+
 function formatDate(iso: string | null | undefined) {
   if (!iso) return "";
   return iso.slice(0, 10);
 }
 
-function pushSection(lines: string[], title: string, headers: string[], rows: string[][]) {
-  lines.push(title);
-  lines.push(headers.map(csvEscape).join(","));
+function toCsv(rows: CsvRow[], headers: string[]) {
+  const lines = [headers.map(csvEscape).join(",")];
   for (const row of rows) {
-    lines.push(row.map((value) => csvEscape(value ?? "")).join(","));
+    lines.push(headers.map((header) => csvEscape(row[header] ?? "")).join(","));
   }
-  lines.push("");
+  return lines.join("\n");
 }
 
 export function buildReportingPeriodCsv(summary: NonNullable<ReportingSummaryResult["summary"]>) {
-  const lines: string[] = [];
+  const headers = [
+    "section",
+    "recordType",
+    "periodId",
+    "periodStartDate",
+    "periodEndDate",
+    "status",
+    "causeId",
+    "causeName",
+    "is501c3",
+    "description",
+    "paidAt",
+    "filedAt",
+    "processedAt",
+    "paymentMethod",
+    "referenceId",
+    "shopifyPayoutId",
+    "metric",
+    "value",
+    "allocatedAmount",
+    "disbursedAmount",
+    "remainingAmount",
+    "currentOutstanding",
+    "priorOutstanding",
+    "totalOutstanding",
+    "extraContributionAmount",
+    "feesCoveredAmount",
+    "delta",
+    "notes",
+    "applicationPeriods",
+    "redistributions",
+  ];
 
-  pushSection(lines, "Period", ["Field", "Value"], [
-    ["Status", summary.period.status],
-    ["Start date", formatDate(summary.period.startDate)],
-    ["End date", formatDate(summary.period.endDate)],
-    ["Payout id", summary.period.shopifyPayoutId ?? ""],
-    ["Closed at", summary.period.closedAt ?? ""],
-  ]);
+  const basePeriod = {
+    periodId: summary.period.id,
+    periodStartDate: formatDate(summary.period.startDate),
+    periodEndDate: formatDate(summary.period.endDate),
+    status: summary.period.status,
+    shopifyPayoutId: summary.period.shopifyPayoutId ?? "",
+  };
 
-  pushSection(lines, "Track 1", ["Field", "Value"], [
-    ["Total net contribution", summary.track1.totalNetContribution],
-    ["Shopify charges", summary.track1.shopifyCharges],
-    ["Donation pool", summary.track1.donationPool],
-    ["Surplus carry-forward", summary.track1.taxTrueUpSurplusApplied],
-    ["Shortfall carry-forward", summary.track1.taxTrueUpShortfallApplied],
-  ]);
+  const rows: CsvRow[] = [
+    {
+      ...basePeriod,
+      section: "period",
+      recordType: "period",
+      metric: "closedAt",
+      value: formatDate(summary.period.closedAt),
+    },
+    {
+      ...basePeriod,
+      section: "track1",
+      recordType: "metric",
+      metric: "totalNetContribution",
+      value: summary.track1.totalNetContribution,
+    },
+    {
+      ...basePeriod,
+      section: "track1",
+      recordType: "metric",
+      metric: "shopifyCharges",
+      value: summary.track1.shopifyCharges,
+    },
+    {
+      ...basePeriod,
+      section: "track1",
+      recordType: "metric",
+      metric: "donationPool",
+      value: summary.track1.donationPool,
+    },
+    {
+      ...basePeriod,
+      section: "track1",
+      recordType: "metric",
+      metric: "surplusCarryForward",
+      value: summary.track1.taxTrueUpSurplusApplied,
+    },
+    {
+      ...basePeriod,
+      section: "track1",
+      recordType: "metric",
+      metric: "shortfallCarryForward",
+      value: summary.track1.taxTrueUpShortfallApplied,
+    },
+    ...summary.track1.allocations.map<CsvRow>((allocation) => ({
+      ...basePeriod,
+      section: "allocations",
+      recordType: "allocation",
+      causeId: allocation.causeId,
+      causeName: allocation.causeName,
+      is501c3: allocation.is501c3 ? "Yes" : "No",
+      allocatedAmount: allocation.allocated,
+      disbursedAmount: allocation.disbursed,
+      remainingAmount: new Prisma.Decimal(allocation.allocated)
+        .sub(new Prisma.Decimal(allocation.disbursed))
+        .toDecimalPlaces(2, Prisma.Decimal.ROUND_FLOOR)
+        .toString(),
+    })),
+    ...summary.causePayables.flatMap<CsvRow>((payable) => [
+      {
+        ...basePeriod,
+        section: "payables",
+        recordType: "causePayable",
+        causeId: payable.causeId,
+        causeName: payable.causeName,
+        is501c3: payable.is501c3 ? "Yes" : "No",
+        currentOutstanding: payable.currentOutstanding,
+        priorOutstanding: payable.priorOutstanding,
+        totalOutstanding: payable.totalOutstanding,
+        notes: payable.overdue ? "Overdue" : "",
+      },
+      ...payable.periods.map((period) => ({
+        ...basePeriod,
+        section: "payables",
+        recordType: "payablePeriod",
+        causeId: payable.causeId,
+        causeName: payable.causeName,
+        periodId: period.periodId,
+        periodStartDate: formatDate(period.periodStartDate),
+        periodEndDate: formatDate(period.periodEndDate),
+        value: period.amount,
+      })),
+    ]),
+    ...summary.charges.map<CsvRow>((charge) => ({
+      ...basePeriod,
+      section: "charges",
+      recordType: "charge",
+      description: charge.description,
+      processedAt: formatDate(charge.processedAt),
+      value: charge.amount,
+    })),
+    ...summary.disbursements.map<CsvRow>((disbursement) => ({
+      ...basePeriod,
+      section: "disbursements",
+      recordType: "disbursement",
+      causeId: disbursement.causeId,
+      causeName: disbursement.causeName,
+      paidAt: formatDate(disbursement.paidAt),
+      paymentMethod: disbursement.paymentMethod,
+      referenceId: disbursement.referenceId ?? "",
+      value: disbursement.amount,
+      allocatedAmount: disbursement.allocatedAmount,
+      extraContributionAmount: disbursement.extraContributionAmount,
+      feesCoveredAmount: disbursement.feesCoveredAmount,
+      applicationPeriods: disbursement.applications
+        .map((application) => `${formatDate(application.periodStartDate)}..${formatDate(application.periodEndDate)}=${application.amount}`)
+        .join(" | "),
+    })),
+    {
+      ...basePeriod,
+      section: "track2",
+      recordType: "metric",
+      metric: "deductionPool",
+      value: summary.track2.deductionPool,
+    },
+    {
+      ...basePeriod,
+      section: "track2",
+      recordType: "metric",
+      metric: "taxableExposure",
+      value: summary.track2.taxableExposure,
+    },
+    {
+      ...basePeriod,
+      section: "track2",
+      recordType: "metric",
+      metric: "widgetTaxSuppressed",
+      value: summary.track2.widgetTaxSuppressed ? "Yes" : "No",
+    },
+    {
+      ...basePeriod,
+      section: "track2",
+      recordType: "metric",
+      metric: "taxableBase",
+      value: summary.track2.taxableBase,
+    },
+    {
+      ...basePeriod,
+      section: "track2",
+      recordType: "metric",
+      metric: "taxableWeight",
+      value: summary.track2.taxableWeight,
+    },
+    {
+      ...basePeriod,
+      section: "track2",
+      recordType: "metric",
+      metric: "estimatedTaxReserve",
+      value: summary.track2.estimatedTaxReserve,
+    },
+    {
+      ...basePeriod,
+      section: "track2",
+      recordType: "metric",
+      metric: "effectiveTaxRate",
+      value: summary.track2.effectiveTaxRate ?? "",
+    },
+    {
+      ...basePeriod,
+      section: "track2",
+      recordType: "metric",
+      metric: "taxDeductionMode",
+      value: summary.track2.taxDeductionMode,
+    },
+    {
+      ...basePeriod,
+      section: "track2",
+      recordType: "metric",
+      metric: "businessExpenseTotal",
+      value: summary.track2.businessExpenseTotal,
+    },
+    {
+      ...basePeriod,
+      section: "track2",
+      recordType: "metric",
+      metric: "allocation501c3Total",
+      value: summary.track2.allocation501c3Total,
+    },
+    ...summary.taxTrueUps.map<CsvRow>((trueUp) => ({
+      ...basePeriod,
+      section: "taxTrueUps",
+      recordType: "taxTrueUp",
+      filedAt: formatDate(trueUp.filedAt),
+      value: trueUp.actualTax,
+      allocatedAmount: trueUp.estimatedTax,
+      delta: trueUp.delta,
+      notes: trueUp.redistributionNotes ?? "",
+      redistributions: trueUp.redistributions
+        .map((redistribution) => `${redistribution.causeName}=${redistribution.amount}`)
+        .join(" | "),
+    })),
+  ];
 
-  pushSection(lines, "Cause allocations", ["Cause", "501c3", "Allocated", "Disbursed"], summary.track1.allocations.map((allocation) => [
-    allocation.causeName,
-    allocation.is501c3 ? "Yes" : "No",
-    allocation.allocated,
-    allocation.disbursed,
-  ]));
-
-  pushSection(lines, "Outstanding cause payables", ["Cause", "Current outstanding", "Prior outstanding", "Total outstanding", "Overdue"], summary.causePayables.map((payable) => [
-    payable.causeName,
-    payable.currentOutstanding,
-    payable.priorOutstanding,
-    payable.totalOutstanding,
-    payable.overdue ? "Yes" : "No",
-  ]));
-
-  pushSection(lines, "Shopify charges", ["Description", "Amount", "Processed at"], summary.charges.map((charge) => [
-    charge.description,
-    charge.amount,
-    charge.processedAt ?? "",
-  ]));
-
-  pushSection(lines, "Disbursements", ["Cause", "Paid at", "Allocated", "Extra", "Fees", "Total", "Method", "Reference", "Applications"], summary.disbursements.map((disbursement) => [
-    disbursement.causeName,
-    formatDate(disbursement.paidAt),
-    disbursement.allocatedAmount,
-    disbursement.extraContributionAmount,
-    disbursement.feesCoveredAmount,
-    disbursement.amount,
-    disbursement.paymentMethod,
-    disbursement.referenceId ?? "",
-    disbursement.applications.map((application) => `${formatDate(application.periodStartDate)}..${formatDate(application.periodEndDate)}=${application.amount}`).join(" | "),
-  ]));
-
-  pushSection(lines, "Track 2", ["Field", "Value"], [
-    ["Deduction pool", summary.track2.deductionPool],
-    ["Taxable exposure", summary.track2.taxableExposure],
-    ["Widget tax suppressed", summary.track2.widgetTaxSuppressed ? "Yes" : "No"],
-    ["Taxable base", summary.track2.taxableBase],
-    ["Taxable weight", summary.track2.taxableWeight],
-    ["Estimated tax reserve", summary.track2.estimatedTaxReserve],
-    ["Effective tax rate", summary.track2.effectiveTaxRate ?? ""],
-    ["Tax deduction mode", summary.track2.taxDeductionMode],
-    ["Business expenses", summary.track2.businessExpenseTotal],
-    ["501c3 allocations", summary.track2.allocation501c3Total],
-  ]);
-
-  pushSection(lines, "Tax true-ups", ["Filed at", "Estimated", "Actual", "Delta", "Notes"], summary.taxTrueUps.map((trueUp) => [
-    formatDate(trueUp.filedAt),
-    trueUp.estimatedTax,
-    trueUp.actualTax,
-    trueUp.delta,
-    trueUp.redistributionNotes ?? "",
-  ]));
-
-  return lines.join("\n");
+  return toCsv(rows, headers);
 }
 
 function escapePdfText(value: string) {
@@ -104,7 +267,7 @@ function escapePdfText(value: string) {
 
 function buildSimplePdf(lines: string[]) {
   const objects: string[] = [];
-  const pageLines = 44;
+  const pageLines = 48;
   const pages: string[][] = [];
   for (let index = 0; index < lines.length; index += pageLines) {
     pages.push(lines.slice(index, index + pageLines));
@@ -116,7 +279,7 @@ function buildSimplePdf(lines: string[]) {
   objects.push("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
 
   for (const page of pages) {
-    const contentLines = ["BT", "/F1 10 Tf", "50 792 Td", "14 TL"];
+    const contentLines = ["BT", "/F1 10 Tf", "50 756 Td", "14 TL"];
     page.forEach((line, index) => {
       if (index === 0) {
         contentLines.push(`(${escapePdfText(line)}) Tj`);

--- a/app/services/reportingExport.server.ts
+++ b/app/services/reportingExport.server.ts
@@ -1,0 +1,176 @@
+import { Buffer } from "node:buffer";
+import type { ReportingSummaryResult } from "./reportingSummary.server";
+
+function csvEscape(value: string) {
+  if (value.includes(",") || value.includes("\"") || value.includes("\n")) {
+    return `"${value.replaceAll("\"", "\"\"")}"`;
+  }
+  return value;
+}
+
+function formatDate(iso: string | null | undefined) {
+  if (!iso) return "";
+  return iso.slice(0, 10);
+}
+
+function pushSection(lines: string[], title: string, headers: string[], rows: string[][]) {
+  lines.push(title);
+  lines.push(headers.map(csvEscape).join(","));
+  for (const row of rows) {
+    lines.push(row.map((value) => csvEscape(value ?? "")).join(","));
+  }
+  lines.push("");
+}
+
+export function buildReportingPeriodCsv(summary: NonNullable<ReportingSummaryResult["summary"]>) {
+  const lines: string[] = [];
+
+  pushSection(lines, "Period", ["Field", "Value"], [
+    ["Status", summary.period.status],
+    ["Start date", formatDate(summary.period.startDate)],
+    ["End date", formatDate(summary.period.endDate)],
+    ["Payout id", summary.period.shopifyPayoutId ?? ""],
+    ["Closed at", summary.period.closedAt ?? ""],
+  ]);
+
+  pushSection(lines, "Track 1", ["Field", "Value"], [
+    ["Total net contribution", summary.track1.totalNetContribution],
+    ["Shopify charges", summary.track1.shopifyCharges],
+    ["Donation pool", summary.track1.donationPool],
+    ["Surplus carry-forward", summary.track1.taxTrueUpSurplusApplied],
+    ["Shortfall carry-forward", summary.track1.taxTrueUpShortfallApplied],
+  ]);
+
+  pushSection(lines, "Cause allocations", ["Cause", "501c3", "Allocated", "Disbursed"], summary.track1.allocations.map((allocation) => [
+    allocation.causeName,
+    allocation.is501c3 ? "Yes" : "No",
+    allocation.allocated,
+    allocation.disbursed,
+  ]));
+
+  pushSection(lines, "Outstanding cause payables", ["Cause", "Current outstanding", "Prior outstanding", "Total outstanding", "Overdue"], summary.causePayables.map((payable) => [
+    payable.causeName,
+    payable.currentOutstanding,
+    payable.priorOutstanding,
+    payable.totalOutstanding,
+    payable.overdue ? "Yes" : "No",
+  ]));
+
+  pushSection(lines, "Shopify charges", ["Description", "Amount", "Processed at"], summary.charges.map((charge) => [
+    charge.description,
+    charge.amount,
+    charge.processedAt ?? "",
+  ]));
+
+  pushSection(lines, "Disbursements", ["Cause", "Paid at", "Allocated", "Extra", "Fees", "Total", "Method", "Reference", "Applications"], summary.disbursements.map((disbursement) => [
+    disbursement.causeName,
+    formatDate(disbursement.paidAt),
+    disbursement.allocatedAmount,
+    disbursement.extraContributionAmount,
+    disbursement.feesCoveredAmount,
+    disbursement.amount,
+    disbursement.paymentMethod,
+    disbursement.referenceId ?? "",
+    disbursement.applications.map((application) => `${formatDate(application.periodStartDate)}..${formatDate(application.periodEndDate)}=${application.amount}`).join(" | "),
+  ]));
+
+  pushSection(lines, "Track 2", ["Field", "Value"], [
+    ["Deduction pool", summary.track2.deductionPool],
+    ["Taxable exposure", summary.track2.taxableExposure],
+    ["Widget tax suppressed", summary.track2.widgetTaxSuppressed ? "Yes" : "No"],
+    ["Taxable base", summary.track2.taxableBase],
+    ["Taxable weight", summary.track2.taxableWeight],
+    ["Estimated tax reserve", summary.track2.estimatedTaxReserve],
+    ["Effective tax rate", summary.track2.effectiveTaxRate ?? ""],
+    ["Tax deduction mode", summary.track2.taxDeductionMode],
+    ["Business expenses", summary.track2.businessExpenseTotal],
+    ["501c3 allocations", summary.track2.allocation501c3Total],
+  ]);
+
+  pushSection(lines, "Tax true-ups", ["Filed at", "Estimated", "Actual", "Delta", "Notes"], summary.taxTrueUps.map((trueUp) => [
+    formatDate(trueUp.filedAt),
+    trueUp.estimatedTax,
+    trueUp.actualTax,
+    trueUp.delta,
+    trueUp.redistributionNotes ?? "",
+  ]));
+
+  return lines.join("\n");
+}
+
+function escapePdfText(value: string) {
+  return value.replaceAll("\\", "\\\\").replaceAll("(", "\\(").replaceAll(")", "\\)");
+}
+
+function buildSimplePdf(lines: string[]) {
+  const objects: string[] = [];
+  const pageLines = 44;
+  const pages: string[][] = [];
+  for (let index = 0; index < lines.length; index += pageLines) {
+    pages.push(lines.slice(index, index + pageLines));
+  }
+
+  objects.push("<< /Type /Catalog /Pages 2 0 R >>");
+  const kids = pages.map((_, index) => `${4 + index * 2} 0 R`).join(" ");
+  objects.push(`<< /Type /Pages /Kids [${kids}] /Count ${pages.length} >>`);
+  objects.push("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+
+  for (const page of pages) {
+    const contentLines = ["BT", "/F1 10 Tf", "50 792 Td", "14 TL"];
+    page.forEach((line, index) => {
+      if (index === 0) {
+        contentLines.push(`(${escapePdfText(line)}) Tj`);
+      } else {
+        contentLines.push("T*");
+        contentLines.push(`(${escapePdfText(line)}) Tj`);
+      }
+    });
+    contentLines.push("ET");
+    const content = contentLines.join("\n");
+    const contentObjectId = objects.length + 2;
+    objects.push(`<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents ${contentObjectId} 0 R >>`);
+    objects.push(`<< /Length ${Buffer.byteLength(content, "utf8")} >>\nstream\n${content}\nendstream`);
+  }
+
+  let pdf = "%PDF-1.4\n";
+  const offsets = [0];
+  objects.forEach((object, index) => {
+    offsets.push(Buffer.byteLength(pdf, "utf8"));
+    pdf += `${index + 1} 0 obj\n${object}\nendobj\n`;
+  });
+  const xrefStart = Buffer.byteLength(pdf, "utf8");
+  pdf += `xref\n0 ${objects.length + 1}\n`;
+  pdf += "0000000000 65535 f \n";
+  for (let index = 1; index < offsets.length; index += 1) {
+    pdf += `${offsets[index].toString().padStart(10, "0")} 00000 n \n`;
+  }
+  pdf += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefStart}\n%%EOF`;
+  return Buffer.from(pdf, "utf8");
+}
+
+export function buildReportingPeriodPdf(summary: NonNullable<ReportingSummaryResult["summary"]>) {
+  const lines = [
+    `Reporting period: ${formatDate(summary.period.startDate)} to ${formatDate(summary.period.endDate)}`,
+    `Status: ${summary.period.status}`,
+    `Donation pool: ${summary.track1.donationPool}`,
+    `Shopify charges: ${summary.track1.shopifyCharges}`,
+    `Estimated tax reserve: ${summary.track2.estimatedTaxReserve}`,
+    "",
+    "Cause allocations",
+    ...summary.track1.allocations.map((allocation) => `- ${allocation.causeName}: allocated ${allocation.allocated}, disbursed ${allocation.disbursed}`),
+    "",
+    "Outstanding cause payables",
+    ...summary.causePayables.map((payable) => `- ${payable.causeName}: current ${payable.currentOutstanding}, prior ${payable.priorOutstanding}, total ${payable.totalOutstanding}`),
+    "",
+    "Disbursements",
+    ...summary.disbursements.map((disbursement) => `- ${disbursement.causeName} paid ${formatDate(disbursement.paidAt)} total ${disbursement.amount} via ${disbursement.paymentMethod}`),
+    "",
+    "Shopify charges",
+    ...summary.charges.map((charge) => `- ${charge.description}: ${charge.amount}`),
+    "",
+    "Tax true-ups",
+    ...summary.taxTrueUps.map((trueUp) => `- filed ${formatDate(trueUp.filedAt)} estimated ${trueUp.estimatedTax}, actual ${trueUp.actualTax}, delta ${trueUp.delta}`),
+  ];
+
+  return buildSimplePdf(lines);
+}

--- a/app/services/reportingSummary.server.ts
+++ b/app/services/reportingSummary.server.ts
@@ -1,0 +1,546 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "../db.server";
+import { listOutstandingCauseAllocations } from "./causePayables.server";
+import { createReceiptStorage } from "./receiptStorage.server";
+import { calculateEstimatedTaxForPeriod } from "./taxTrueUpService.server";
+import { normalizeTaxDeductionMode } from "./taxReserve.server";
+
+const ZERO = new Prisma.Decimal(0);
+const ADJUSTMENT_RATIO_GUARD = new Prisma.Decimal(10);
+
+function addAllocation(
+  allocations: Map<string, { causeId: string; causeName: string; is501c3: boolean; allocated: Prisma.Decimal }>,
+  allocation: { causeId: string; causeName: string; is501c3: boolean; allocated: Prisma.Decimal },
+) {
+  const current = allocations.get(allocation.causeId);
+  if (!current) {
+    allocations.set(allocation.causeId, allocation);
+    return;
+  }
+
+  allocations.set(allocation.causeId, {
+    ...current,
+    allocated: current.allocated.add(allocation.allocated),
+  });
+}
+
+function computeAdjustedAllocationAmount({
+  baseAmount,
+  lineNetContribution,
+  lineAdjustmentTotal,
+}: {
+  baseAmount: Prisma.Decimal;
+  lineNetContribution: Prisma.Decimal;
+  lineAdjustmentTotal: Prisma.Decimal;
+}) {
+  if (lineNetContribution.equals(0) || lineAdjustmentTotal.equals(0)) {
+    return baseAmount;
+  }
+
+  const ratio = lineAdjustmentTotal.div(lineNetContribution);
+  if (ratio.abs().greaterThan(ADJUSTMENT_RATIO_GUARD)) {
+    return baseAmount;
+  }
+
+  return baseAmount.add(baseAmount.mul(ratio));
+}
+
+export type ReportingSummaryResult = Awaited<ReturnType<typeof buildReportingSummary>>;
+
+export async function buildReportingSummary(shopId: string, requestedPeriodId?: string | null, db = prisma) {
+  const periods = await db.reportingPeriod.findMany({
+    where: { shopId },
+    orderBy: [{ startDate: "desc" }, { createdAt: "desc" }],
+    select: {
+      id: true,
+      status: true,
+      source: true,
+      startDate: true,
+      endDate: true,
+      shopifyPayoutId: true,
+      closedAt: true,
+    },
+  });
+
+  if (periods.length === 0) {
+    return {
+      periods: [],
+      selectedPeriodId: null,
+      summary: null,
+    };
+  }
+
+  const selectedPeriod = periods.find((period) => period.id === requestedPeriodId) ?? periods[0];
+
+  const [shop, snapshotLines, closedAllocations, expensesSummary, chargesSummary, charges, disbursements, taxTrueUps, carryForwardTrueUps, activeCauses, outstandingAllocations] =
+    await Promise.all([
+      db.shop.findUnique({
+        where: { shopId },
+        select: {
+          effectiveTaxRate: true,
+          taxDeductionMode: true,
+        },
+      }),
+      db.orderSnapshotLine.findMany({
+        where: {
+          shopId,
+          snapshot: {
+            createdAt: {
+              gte: selectedPeriod.startDate,
+              lt: selectedPeriod.endDate,
+            },
+          },
+        },
+        select: {
+          netContribution: true,
+          adjustments: { select: { netContribAdj: true } },
+          causeAllocations: {
+            select: { causeId: true, causeName: true, is501c3: true, amount: true },
+          },
+        },
+      }),
+      db.causeAllocation.findMany({
+        where: {
+          shopId,
+          periodId: selectedPeriod.id,
+        },
+        select: {
+          causeId: true,
+          causeName: true,
+          is501c3: true,
+          allocated: true,
+          disbursed: true,
+        },
+      }),
+      db.businessExpense.aggregate({
+        where: {
+          shopId,
+          expenseDate: {
+            gte: selectedPeriod.startDate,
+            lt: selectedPeriod.endDate,
+          },
+        },
+        _sum: { amount: true },
+      }),
+      db.shopifyChargeTransaction.aggregate({
+        where: {
+          shopId,
+          OR: [
+            { periodId: selectedPeriod.id },
+            {
+              periodId: null,
+              processedAt: {
+                gte: selectedPeriod.startDate,
+                lt: selectedPeriod.endDate,
+              },
+            },
+          ],
+        },
+        _sum: { amount: true },
+      }),
+      db.shopifyChargeTransaction.findMany({
+        where: {
+          shopId,
+          OR: [
+            { periodId: selectedPeriod.id },
+            {
+              periodId: null,
+              processedAt: {
+                gte: selectedPeriod.startDate,
+                lt: selectedPeriod.endDate,
+              },
+            },
+          ],
+        },
+        orderBy: [{ processedAt: "desc" }, { createdAt: "desc" }],
+        take: 15,
+        select: {
+          id: true,
+          description: true,
+          amount: true,
+          processedAt: true,
+        },
+      }),
+      db.disbursement.findMany({
+        where: {
+          shopId,
+          periodId: selectedPeriod.id,
+        },
+        orderBy: [{ paidAt: "desc" }, { createdAt: "desc" }],
+        select: {
+          id: true,
+          causeId: true,
+          amount: true,
+          allocatedAmount: true,
+          extraContributionAmount: true,
+          feesCoveredAmount: true,
+          paidAt: true,
+          paymentMethod: true,
+          referenceId: true,
+          receiptFileKey: true,
+          cause: {
+            select: {
+              name: true,
+            },
+          },
+          applications: {
+            select: {
+              amount: true,
+              causeAllocation: {
+                select: {
+                  periodId: true,
+                  period: {
+                    select: {
+                      startDate: true,
+                      endDate: true,
+                    },
+                  },
+                },
+              },
+            },
+            orderBy: {
+              causeAllocation: {
+                period: {
+                  endDate: "asc",
+                },
+              },
+            },
+          },
+        },
+      }),
+      db.taxTrueUp.findMany({
+        where: {
+          shopId,
+          periodId: selectedPeriod.id,
+        },
+        orderBy: [{ filedAt: "desc" }, { createdAt: "desc" }],
+        select: {
+          id: true,
+          estimatedTax: true,
+          actualTax: true,
+          delta: true,
+          filedAt: true,
+          redistributionNotes: true,
+          appliedPeriodId: true,
+          redistributions: {
+            select: {
+              causeId: true,
+              causeName: true,
+              amount: true,
+            },
+          },
+        },
+      }),
+      db.taxTrueUp.findMany({
+        where: {
+          shopId,
+          appliedPeriodId: selectedPeriod.id,
+        },
+        select: {
+          id: true,
+          periodId: true,
+          delta: true,
+          redistributions: {
+            select: {
+              causeId: true,
+              causeName: true,
+              amount: true,
+            },
+          },
+        },
+      }),
+      db.cause.findMany({
+        where: {
+          shopId,
+          status: "active",
+        },
+        orderBy: { name: "asc" },
+        select: {
+          id: true,
+          name: true,
+        },
+      }),
+      listOutstandingCauseAllocations(
+        shopId,
+        {
+          throughPeriodEndDate: selectedPeriod.endDate,
+        },
+        db,
+      ),
+    ]);
+
+  const allocationMap = new Map<string, { causeId: string; causeName: string; is501c3: boolean; allocated: Prisma.Decimal }>();
+  let totalNetContribution = ZERO;
+
+  for (const line of snapshotLines) {
+    const adjustmentTotal = line.adjustments.reduce((sum, adj) => sum.add(adj.netContribAdj), ZERO);
+    totalNetContribution = totalNetContribution.add(line.netContribution).add(adjustmentTotal);
+
+    for (const allocation of line.causeAllocations) {
+      const adjusted = computeAdjustedAllocationAmount({
+        baseAmount: allocation.amount,
+        lineNetContribution: line.netContribution,
+        lineAdjustmentTotal: adjustmentTotal,
+      });
+
+      addAllocation(allocationMap, {
+        causeId: allocation.causeId,
+        causeName: allocation.causeName,
+        is501c3: allocation.is501c3,
+        allocated: adjusted,
+      });
+    }
+  }
+
+  const expenseTotal = expensesSummary._sum.amount ?? ZERO;
+  const shopifyCharges = chargesSummary._sum.amount ?? ZERO;
+  const useClosedAllocations = selectedPeriod.status === "CLOSED" && closedAllocations.length > 0;
+  let allocationRows = useClosedAllocations
+    ? closedAllocations.map((allocation) => ({
+        causeId: allocation.causeId,
+        causeName: allocation.causeName,
+        is501c3: allocation.is501c3,
+        allocated: allocation.allocated,
+        disbursed: allocation.disbursed,
+      }))
+    : Array.from(allocationMap.values()).map((allocation) => ({
+        causeId: allocation.causeId,
+        causeName: allocation.causeName,
+        is501c3: allocation.is501c3,
+        allocated: allocation.allocated,
+        disbursed: ZERO,
+      }));
+
+  if (carryForwardTrueUps.length > 0) {
+    const allocationMapWithCarryForward = new Map(
+      allocationRows.map((allocation) => [
+        allocation.causeId,
+        {
+          ...allocation,
+        },
+      ]),
+    );
+
+    for (const trueUp of carryForwardTrueUps) {
+      for (const redistribution of trueUp.redistributions) {
+        const existing = allocationMapWithCarryForward.get(redistribution.causeId);
+        if (existing) {
+          existing.allocated = existing.allocated.add(redistribution.amount);
+          continue;
+        }
+
+        allocationMapWithCarryForward.set(redistribution.causeId, {
+          causeId: redistribution.causeId,
+          causeName: redistribution.causeName,
+          is501c3: false,
+          allocated: redistribution.amount,
+          disbursed: ZERO,
+        });
+      }
+    }
+
+    allocationRows = Array.from(allocationMapWithCarryForward.values());
+  }
+
+  const allocation501c3Total = allocationRows.reduce(
+    (sum, allocation) => (allocation.is501c3 ? sum.add(allocation.allocated) : sum),
+    ZERO,
+  );
+
+  const deductionPool = expenseTotal.add(allocation501c3Total);
+  const taxableExposure = totalNetContribution.sub(deductionPool);
+  const widgetTaxSuppressed = taxableExposure.lessThanOrEqualTo(0);
+  const taxEstimate = await calculateEstimatedTaxForPeriod(shopId, selectedPeriod.id, db);
+  const carryForwardSurplus = carryForwardTrueUps.reduce(
+    (sum, trueUp) => (trueUp.delta.greaterThan(ZERO) ? sum.add(trueUp.delta) : sum),
+    ZERO,
+  );
+  const carryForwardShortfall = carryForwardTrueUps.reduce(
+    (sum, trueUp) => (trueUp.delta.lessThan(ZERO) ? sum.add(trueUp.delta.abs()) : sum),
+    ZERO,
+  );
+  const receiptStorage = createReceiptStorage();
+  const disbursementRows = await Promise.all(
+    disbursements.map(async (disbursement) => ({
+      id: disbursement.id,
+      causeId: disbursement.causeId,
+      causeName: disbursement.cause.name,
+      amount: disbursement.amount.toString(),
+      allocatedAmount: disbursement.allocatedAmount.toString(),
+      extraContributionAmount: disbursement.extraContributionAmount.toString(),
+      feesCoveredAmount: disbursement.feesCoveredAmount.toString(),
+      paidAt: disbursement.paidAt.toISOString(),
+      paymentMethod: disbursement.paymentMethod,
+      referenceId: disbursement.referenceId ?? null,
+      receiptUrl: disbursement.receiptFileKey
+        ? await receiptStorage.getSignedReadUrl({
+            key: disbursement.receiptFileKey,
+            expiresInSeconds: 60 * 60,
+          })
+        : null,
+      applications: disbursement.applications.map((application) => ({
+        periodId: application.causeAllocation.periodId,
+        periodStartDate: application.causeAllocation.period.startDate.toISOString(),
+        periodEndDate: application.causeAllocation.period.endDate.toISOString(),
+        amount: application.amount.toString(),
+      })),
+    })),
+  );
+
+  const causePayablesMap = new Map<
+    string,
+    {
+      causeId: string;
+      causeName: string;
+      is501c3: boolean;
+      currentOutstanding: Prisma.Decimal;
+      priorOutstanding: Prisma.Decimal;
+      periods: Array<{
+        periodId: string;
+        periodStartDate: string;
+        periodEndDate: string;
+        amount: string;
+      }>;
+    }
+  >();
+
+  for (const allocation of outstandingAllocations) {
+    const existing = causePayablesMap.get(allocation.causeId) ?? {
+      causeId: allocation.causeId,
+      causeName: allocation.causeName,
+      is501c3: allocation.is501c3,
+      currentOutstanding: ZERO,
+      priorOutstanding: ZERO,
+      periods: [],
+    };
+
+    if (allocation.periodId === selectedPeriod.id) {
+      existing.currentOutstanding = existing.currentOutstanding.add(allocation.remaining);
+    } else {
+      existing.priorOutstanding = existing.priorOutstanding.add(allocation.remaining);
+    }
+
+    existing.periods.push({
+      periodId: allocation.periodId,
+      periodStartDate: allocation.periodStartDate.toISOString(),
+      periodEndDate: allocation.periodEndDate.toISOString(),
+      amount: allocation.remaining.toString(),
+    });
+    causePayablesMap.set(allocation.causeId, existing);
+  }
+
+  if (selectedPeriod.status === "OPEN") {
+    for (const allocation of allocationRows) {
+      const existing = causePayablesMap.get(allocation.causeId) ?? {
+        causeId: allocation.causeId,
+        causeName: allocation.causeName,
+        is501c3: allocation.is501c3,
+        currentOutstanding: ZERO,
+        priorOutstanding: ZERO,
+        periods: [],
+      };
+
+      existing.currentOutstanding = existing.currentOutstanding.add(new Prisma.Decimal(allocation.allocated));
+      causePayablesMap.set(allocation.causeId, existing);
+    }
+  }
+
+  const causePayables = Array.from(causePayablesMap.values()).map((payable) => {
+    const totalOutstanding = payable.currentOutstanding.add(payable.priorOutstanding);
+    return {
+      causeId: payable.causeId,
+      causeName: payable.causeName,
+      is501c3: payable.is501c3,
+      currentOutstanding: payable.currentOutstanding.toString(),
+      priorOutstanding: payable.priorOutstanding.toString(),
+      totalOutstanding: totalOutstanding.toString(),
+      overdue: payable.priorOutstanding.greaterThan(ZERO),
+      periods: payable.periods,
+    };
+  });
+
+  return {
+    periods: periods.map((period) => ({
+      id: period.id,
+      status: period.status,
+      source: period.source,
+      startDate: period.startDate.toISOString(),
+      endDate: period.endDate.toISOString(),
+      shopifyPayoutId: period.shopifyPayoutId ?? null,
+      closedAt: period.closedAt?.toISOString() ?? null,
+    })),
+    selectedPeriodId: selectedPeriod.id,
+    summary: {
+      period: {
+        id: selectedPeriod.id,
+        status: selectedPeriod.status,
+        startDate: selectedPeriod.startDate.toISOString(),
+        endDate: selectedPeriod.endDate.toISOString(),
+        shopifyPayoutId: selectedPeriod.shopifyPayoutId ?? null,
+        closedAt: selectedPeriod.closedAt?.toISOString() ?? null,
+      },
+      track1: {
+        totalNetContribution: totalNetContribution.toString(),
+        shopifyCharges: shopifyCharges.toString(),
+        donationPool: totalNetContribution.sub(shopifyCharges).add(carryForwardSurplus).sub(carryForwardShortfall).toString(),
+        taxTrueUpSurplusApplied: carryForwardSurplus.toString(),
+        taxTrueUpShortfallApplied: carryForwardShortfall.toString(),
+        allocations: allocationRows.map((allocation) => ({
+          causeId: allocation.causeId,
+          causeName: allocation.causeName,
+          is501c3: allocation.is501c3,
+          allocated: allocation.allocated.toString(),
+          disbursed: allocation.disbursed.toString(),
+        })),
+      },
+      track2: {
+        deductionPool: deductionPool.toString(),
+        taxableExposure: taxableExposure.toString(),
+        widgetTaxSuppressed,
+        taxableBase: taxEstimate.taxableBase.toString(),
+        taxableWeight: taxEstimate.taxableWeight.toString(),
+        estimatedTaxReserve: taxEstimate.estimatedTaxReserve.toString(),
+        effectiveTaxRate: shop?.effectiveTaxRate?.toString() ?? null,
+        taxDeductionMode: normalizeTaxDeductionMode(shop?.taxDeductionMode),
+        businessExpenseTotal: expenseTotal.toString(),
+        allocation501c3Total: allocation501c3Total.toString(),
+      },
+      charges: charges.map((charge) => ({
+        id: charge.id,
+        description: charge.description ?? "Shopify charge",
+        amount: charge.amount.toString(),
+        processedAt: charge.processedAt?.toISOString() ?? null,
+      })),
+      disbursements: disbursementRows,
+      causePayables,
+      taxTrueUps: taxTrueUps.map((trueUp) => ({
+        id: trueUp.id,
+        estimatedTax: trueUp.estimatedTax.toString(),
+        actualTax: trueUp.actualTax.toString(),
+        delta: trueUp.delta.toString(),
+        filedAt: trueUp.filedAt.toISOString(),
+        redistributionNotes: trueUp.redistributionNotes ?? null,
+        appliedPeriodId: trueUp.appliedPeriodId ?? null,
+        redistributions: trueUp.redistributions.map((redistribution) => ({
+          causeId: redistribution.causeId,
+          causeName: redistribution.causeName,
+          amount: redistribution.amount.toString(),
+        })),
+      })),
+      carryForwardTrueUps: carryForwardTrueUps.map((trueUp) => ({
+        id: trueUp.id,
+        periodId: trueUp.periodId,
+        delta: trueUp.delta.toString(),
+        redistributions: trueUp.redistributions.map((redistribution) => ({
+          causeId: redistribution.causeId,
+          causeName: redistribution.causeName,
+          amount: redistribution.amount.toString(),
+        })),
+      })),
+      activeCauses: activeCauses.map((cause) => ({
+        id: cause.id,
+        name: cause.name,
+      })),
+    },
+  };
+}

--- a/docs/current-implementation-status.md
+++ b/docs/current-implementation-status.md
@@ -6,7 +6,7 @@ This file is intentionally lightweight and operational. It should summarize real
 
 **Project:** Count On Us  
 **Date:** April 9, 2026  
-**Summary:** Phase 1, Phase 2, and Phase 3 are complete. Phase 4 is now well underway, with the reporting foundation, dashboard, charge sync groundwork, disbursement logging, receipt storage, and tax true-up merged. Current focus is finishing the remaining reporting workflows, starting with rolling cause payables, cross-period disbursement application, and export support.
+**Summary:** Phase 1, Phase 2, and Phase 3 are complete. Phase 4 is now well underway, with the reporting foundation, dashboard, charge sync groundwork, disbursement logging, receipt storage, tax true-up, and export support implemented. Current focus is finishing the remaining reporting workflows, starting with rolling cause payables, cross-period disbursement application, and audit-log browsing.
 
 ---
 
@@ -14,7 +14,7 @@ This file is intentionally lightweight and operational. It should summarize real
 
 - **Phase 1:** Complete
 - **Phase 2:** Complete
-- **Current focus:** Phase 4 reporting completion, with rolling cause payables and cross-period disbursement application actively in progress
+- **Current focus:** Phase 4 reporting completion, with rolling cause payables and cross-period disbursement application actively in progress and export support on the active branch
 - **Phase 3:** Complete
 
 ---
@@ -127,7 +127,8 @@ These are useful next items, but they are no longer blockers for closing Phase 3
 - [x] Tax true-up
 - [~] Rolling cause payables and cross-period disbursement application
   ADR direction is accepted and the first implementation tranche is in progress on the active branch.
-- [ ] Export flows
+- [~] Export flows
+  CSV and PDF reporting-period export support are implemented on the active branch and awaiting review/merge.
 - [ ] Audit log browsing UI
 
 ---

--- a/tests/ui/reporting-workflow.spec.ts
+++ b/tests/ui/reporting-workflow.spec.ts
@@ -107,3 +107,22 @@ test("reporting dashboard can record a surplus tax true-up", async ({ page, requ
   await expect(trueUpRow).toContainText("$8.00");
   await expect(trueUpRow).toContainText("$2.00");
 });
+
+test("reporting dashboard export routes return csv and pdf downloads", async ({ request }) => {
+  const bootstrapResponse = await request.get("/ui-fixtures/reporting-bootstrap");
+  expect(bootstrapResponse.ok()).toBeTruthy();
+
+  const bootstrap = await bootstrapResponse.json();
+  const csvResponse = await request.get(`/app/reporting-export?__playwrightShop=${encodeURIComponent(bootstrap.shopId)}&periodId=${encodeURIComponent(bootstrap.closedPeriodId)}&format=csv`);
+  expect(csvResponse.ok()).toBeTruthy();
+  expect(csvResponse.headers()["content-type"]).toContain("text/csv");
+  expect(csvResponse.headers()["content-disposition"]).toContain(".csv");
+  expect(await csvResponse.text()).toContain("Outstanding cause payables");
+
+  const pdfResponse = await request.get(`/app/reporting-export?__playwrightShop=${encodeURIComponent(bootstrap.shopId)}&periodId=${encodeURIComponent(bootstrap.closedPeriodId)}&format=pdf`);
+  expect(pdfResponse.ok()).toBeTruthy();
+  expect(pdfResponse.headers()["content-type"]).toContain("application/pdf");
+  expect(pdfResponse.headers()["content-disposition"]).toContain(".pdf");
+  const pdfBuffer = await pdfResponse.body();
+  expect(Buffer.from(pdfBuffer).subarray(0, 8).toString("utf8")).toContain("%PDF-1.4");
+});


### PR DESCRIPTION
## Summary
- add reporting period CSV and PDF export downloads
- extract shared reporting summary building for the page and export route
- use authenticated in-app downloads so exports do not bounce to login
- fix CSV output to be a real tabular CSV and adjust PDF layout so content is not clipped
- update status tracking for Phase 4 export progress

## Validation
- npx tsc --noEmit
- npm run lint
- npm test -- --run app/services/reportingExport.server.test.ts
- focused reporting and export Playwright coverage