### PR TITLE
Add provider connections and storefront donation widget foundation

### DIFF
--- a/app/routes/api.widget.products.$productId.tsx
+++ b/app/routes/api.widget.products.$productId.tsx
@@ -34,9 +34,41 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const productId = params.productId?.trim();
   const url = new URL(request.url);
   const metadataOnly = url.searchParams.get("metadataOnly") === "1";
+  const variantId = url.searchParams.get("variantId")?.trim() || "";
+  const quantityParam = url.searchParams.get("quantity")?.trim() || "";
+  const lineSubtotalParam = url.searchParams.get("lineSubtotal")?.trim() || "";
 
   if (!productId) {
     return errorResponse(400, "VALIDATION_ERROR", "Product ID is required.");
+  }
+
+  let lineContext:
+    | {
+        variantShopifyId: string;
+        quantity: number;
+        lineSubtotal: Prisma.Decimal | null;
+      }
+    | undefined;
+
+  if (!metadataOnly && variantId) {
+    const quantity = Number.parseInt(quantityParam || "1", 10);
+    if (!Number.isFinite(quantity) || quantity < 1) {
+      return errorResponse(400, "VALIDATION_ERROR", "Quantity must be a positive integer.");
+    }
+
+    let lineSubtotal: Prisma.Decimal | null = null;
+    if (lineSubtotalParam) {
+      if (!/^\d+(\.\d{1,2})?$/.test(lineSubtotalParam)) {
+        return errorResponse(400, "VALIDATION_ERROR", "Line subtotal must be a valid money amount.");
+      }
+      lineSubtotal = new Prisma.Decimal(lineSubtotalParam);
+    }
+
+    lineContext = {
+      variantShopifyId: variantId,
+      quantity,
+      lineSubtotal,
+    };
   }
 
   const { shopifyDomain } = await authenticatePublicAppProxyRequest(request);
@@ -65,7 +97,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
 
   const payload = metadataOnly
     ? await buildWidgetProductMetadata(shop.shopId, productId, prisma)
-    : await buildWidgetProductPayload(shop.shopId, productId, prisma);
+    : await buildWidgetProductPayload(shop.shopId, productId, prisma, lineContext);
 
   if (!payload) {
     return errorResponse(404, "NOT_FOUND", "Product not found for this shop.", rateLimit.headers);

--- a/app/routes/api.widget.products.$productId.tsx
+++ b/app/routes/api.widget.products.$productId.tsx
@@ -1,4 +1,5 @@
 import type { LoaderFunctionArgs } from "@remix-run/node";
+import { Prisma } from "@prisma/client";
 
 import { prisma } from "../db.server";
 import {
@@ -39,10 +40,9 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   }
 
   const { shopifyDomain } = await authenticatePublicAppProxyRequest(request);
-  const shop = await prisma.shop.findUnique({
-    where: { shopifyDomain },
-    select: { shopId: true },
-  });
+  const [shop] = await prisma.$queryRaw<Array<{ shopId: string }>>(
+    Prisma.sql`SELECT "shopId" FROM "Shop" WHERE "shopifyDomain" = ${shopifyDomain} LIMIT 1`,
+  );
 
   if (!shop) {
     return errorResponse(404, "NOT_FOUND", "Shop not found for widget request.");

--- a/app/routes/app.api.widget.products.$productId.tsx
+++ b/app/routes/app.api.widget.products.$productId.tsx
@@ -1,0 +1,1 @@
+export { loader } from "./api.widget.products.$productId";

--- a/app/routes/app.order-history._index.tsx
+++ b/app/routes/app.order-history._index.tsx
@@ -107,17 +107,20 @@ function buildOrderHistoryHref({
   startDate,
   endDate,
   cursor,
+  playwrightShop,
 }: {
   origin: string;
   startDate?: string;
   endDate?: string;
   cursor?: string | null;
+  playwrightShop?: string | null;
 }) {
   const params = new URLSearchParams();
   if (origin && origin !== "all") params.set("origin", origin);
   if (startDate) params.set("startDate", startDate);
   if (endDate) params.set("endDate", endDate);
   if (cursor) params.set("cursor", cursor);
+  if (playwrightShop) params.set("__playwrightShop", playwrightShop);
   const query = params.toString();
   return query ? `/app/order-history?${query}` : "/app/order-history";
 }
@@ -128,18 +131,21 @@ function FilterLink({
   label,
   startDate,
   endDate,
+  playwrightShop,
 }: {
   currentOrigin: string;
   targetOrigin: string;
   label: string;
   startDate?: string;
   endDate?: string;
+  playwrightShop?: string | null;
 }) {
   const isActive = currentOrigin === targetOrigin;
   const href = buildOrderHistoryHref({
     origin: targetOrigin,
     startDate,
     endDate,
+    playwrightShop,
   });
 
   return (
@@ -165,6 +171,7 @@ export default function OrderHistoryPage() {
   const { formatMoney } = useAppLocalization();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const playwrightShop = searchParams.get("__playwrightShop");
 
   function applyDateFilters(form: HTMLFormElement) {
     const formData = new FormData(form);
@@ -180,7 +187,8 @@ export default function OrderHistoryPage() {
     if (nextEndDate) params.set("endDate", nextEndDate);
     else params.delete("endDate");
 
-    navigate(`?${params.toString()}`);
+    const query = params.toString();
+    navigate(query ? `?${query}` : ".");
   }
 
   return (
@@ -193,14 +201,29 @@ export default function OrderHistoryPage() {
             <HelpText>Order History shows immutable financial snapshots captured at order time or later reconciliation. Net contribution here means revenue remaining after resolved production costs for the order lines.</HelpText>
             <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap", alignItems: "center" }}>
               <strong>Origin filter</strong>
-              <FilterLink currentOrigin={origin} targetOrigin="all" label="All" startDate={startDate} endDate={endDate} />
-              <FilterLink currentOrigin={origin} targetOrigin="webhook" label="Webhook" startDate={startDate} endDate={endDate} />
+              <FilterLink
+                currentOrigin={origin}
+                targetOrigin="all"
+                label="All"
+                startDate={startDate}
+                endDate={endDate}
+                playwrightShop={playwrightShop}
+              />
+              <FilterLink
+                currentOrigin={origin}
+                targetOrigin="webhook"
+                label="Webhook"
+                startDate={startDate}
+                endDate={endDate}
+                playwrightShop={playwrightShop}
+              />
               <FilterLink
                 currentOrigin={origin}
                 targetOrigin="reconciliation"
                 label="Reconciliation"
                 startDate={startDate}
                 endDate={endDate}
+                playwrightShop={playwrightShop}
               />
             </div>
 
@@ -257,7 +280,7 @@ export default function OrderHistoryPage() {
                   <s-button type="submit" variant="secondary">
                     Apply dates
                   </s-button>
-                  <Link to={buildOrderHistoryHref({ origin })} style={{ alignSelf: "center" }}>
+                  <Link to={buildOrderHistoryHref({ origin, playwrightShop })} style={{ alignSelf: "center" }}>
                     Clear dates
                   </Link>
                 </div>
@@ -309,6 +332,7 @@ export default function OrderHistoryPage() {
                     startDate,
                     endDate,
                     cursor: nextCursor,
+                    playwrightShop,
                   })}
                 >
                   Next page

--- a/app/routes/app.products._index.tsx
+++ b/app/routes/app.products._index.tsx
@@ -1,23 +1,48 @@
-import type { LoaderFunctionArgs } from "@remix-run/node";
-import { Link, useLoaderData, useRouteError } from "@remix-run/react";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
+import { Link, useFetcher, useLoaderData, useRouteError } from "@remix-run/react";
 import { prisma } from "../db.server";
-import { authenticateAdminRequest } from "../utils/admin-auth.server";
+import { jobQueue } from "../jobs/queue.server";
+import { authenticateAdminRequest, isPlaywrightBypassRequest } from "../utils/admin-auth.server";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticateAdminRequest(request);
   const shopId = session.shop;
 
-  const products = await prisma.product.findMany({
-    where: { shopId },
-    orderBy: { title: "asc" },
-    include: {
-      _count: {
-        select: { causeAssignments: true, variants: true },
+  const [shop, latestCatalogSync, products] = await Promise.all([
+    prisma.shop.findUnique({
+      where: { shopId },
+      select: { catalogSynced: true },
+    }),
+    prisma.auditLog.findFirst({
+      where: {
+        shopId,
+        action: "CATALOG_SYNC_COMPLETED",
       },
-    },
-  });
+      orderBy: { createdAt: "desc" },
+      select: {
+        createdAt: true,
+        payload: true,
+      },
+    }),
+    prisma.product.findMany({
+      where: { shopId },
+      orderBy: { title: "asc" },
+      include: {
+        _count: {
+          select: { causeAssignments: true, variants: true },
+        },
+      },
+    }),
+  ]);
 
   return Response.json({
+    catalogSynced: shop?.catalogSynced ?? false,
+    latestCatalogSync: latestCatalogSync
+      ? {
+          completedAt: latestCatalogSync.createdAt.toISOString(),
+          payload: latestCatalogSync.payload,
+        }
+      : null,
     products: products.map((product) => ({
       id: product.id,
       title: product.title,
@@ -26,6 +51,46 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       variantCount: product._count.variants,
       causeAssignmentCount: product._count.causeAssignments,
     })),
+  });
+};
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const { session } = await authenticateAdminRequest(request);
+  const shopId = session.shop;
+  const formData = await request.formData();
+  const intent = formData.get("intent")?.toString();
+
+  if (intent !== "sync-catalog") {
+    return Response.json({ ok: false, message: "Unknown action." }, { status: 400 });
+  }
+
+  await prisma.auditLog.create({
+    data: {
+      shopId,
+      entity: "Shop",
+      action: "CATALOG_SYNC_REQUESTED",
+      actor: "merchant",
+      payload: {
+        source: "products_index",
+      },
+    },
+  });
+
+  if (!isPlaywrightBypassRequest(request)) {
+    await jobQueue.send(
+      "catalog.sync",
+      { shopId },
+      {
+        singletonKey: shopId,
+        singletonSeconds: 15 * 60,
+      },
+    );
+  }
+
+  return Response.json({
+    ok: true,
+    message:
+      "Catalog sync queued. Shopify products and variants will be added or refreshed without deleting your existing local seed data.",
   });
 };
 
@@ -38,16 +103,67 @@ type ProductRow = {
   causeAssignmentCount: number;
 };
 
+type SyncActionData = {
+  ok: boolean;
+  message: string;
+};
+
+function formatSyncDate(value: string | null) {
+  if (!value) return "Not yet completed";
+  return new Date(value).toLocaleString();
+}
+
 export default function ProductsPage() {
-  const { products } = useLoaderData<typeof loader>();
+  const { catalogSynced, latestCatalogSync, products } = useLoaderData<typeof loader>();
+  const syncFetcher = useFetcher<SyncActionData>();
 
   return (
     <>
       <ui-title-bar title="Products" />
       <s-page>
+        <s-section heading="Catalog sync">
+          <div style={{ display: "grid", gap: "0.75rem" }}>
+            <s-text>
+              Sync products and variants from Shopify without removing locally seeded test data. Existing Shopify-backed rows are
+              refreshed in place by `shopifyId`; unrelated local rows are left alone.
+            </s-text>
+            <div style={{ display: "flex", gap: "2rem", flexWrap: "wrap" }}>
+              <div>
+                <strong>Status</strong>
+                <div>{catalogSynced ? "Catalog synced" : "Initial catalog sync still pending"}</div>
+              </div>
+              <div>
+                <strong>Last completed sync</strong>
+                <div>{formatSyncDate(latestCatalogSync?.completedAt ?? null)}</div>
+              </div>
+            </div>
+            {syncFetcher.data?.ok ? (
+              <s-banner tone="success">
+                <s-text>{syncFetcher.data.message}</s-text>
+              </s-banner>
+            ) : null}
+            {syncFetcher.data && !syncFetcher.data.ok ? (
+              <s-banner tone="critical">
+                <s-text>{syncFetcher.data.message}</s-text>
+              </s-banner>
+            ) : null}
+            <syncFetcher.Form method="post">
+              <input type="hidden" name="intent" value="sync-catalog" />
+              <s-button type="submit" variant="primary" disabled={syncFetcher.state !== "idle"}>
+                Sync catalog now
+              </s-button>
+            </syncFetcher.Form>
+          </div>
+        </s-section>
+
         {products.length === 0 ? (
           <s-section heading="No synced products">
-            <s-text>Catalog sync must complete before product-level Cause assignments can be configured.</s-text>
+            <div style={{ display: "grid", gap: "0.75rem" }}>
+              <s-text>Catalog sync must complete before product-level Cause assignments can be configured.</s-text>
+              <s-text color="subdued">
+                Use the sync action above to import your Shopify catalog while keeping any seed data you already have.
+              </s-text>
+            </div>
           </s-section>
         ) : (
           <s-section padding="none">

--- a/app/routes/app.provider-connections.tsx
+++ b/app/routes/app.provider-connections.tsx
@@ -1,12 +1,330 @@
-import type { LoaderFunctionArgs } from "@remix-run/node";
-import { PlaceholderPage } from "../components/PlaceholderPage";
+import { useRef, useState } from "react";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
+import { useFetcher, useLoaderData, useRouteError } from "@remix-run/react";
+
 import { authenticateAdminRequest } from "../utils/admin-auth.server";
+import {
+  disconnectProviderConnection,
+  getProviderConnectionsPageData,
+  savePrintifyConnection,
+} from "../services/providerConnections.server";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
-  await authenticateAdminRequest(request);
-  return null;
+  const { session } = await authenticateAdminRequest(request);
+  return Response.json(await getProviderConnectionsPageData(session.shop));
 };
 
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const { session } = await authenticateAdminRequest(request);
+  const formData = await request.formData();
+  const intent = formData.get("intent")?.toString();
+
+  if (intent === "save-printify-credentials") {
+    try {
+      await savePrintifyConnection({
+        shopId: session.shop,
+        apiKey: formData.get("apiKey")?.toString() ?? "",
+        displayName: formData.get("displayName")?.toString() ?? null,
+      });
+    } catch (error) {
+      if (error instanceof Response) {
+        return Response.json({ ok: false, message: await error.text() });
+      }
+      throw error;
+    }
+
+    return Response.json({
+      ok: true,
+      message: "Printify credentials saved. Live validation and sync will land in a follow-up provider tranche.",
+    });
+  }
+
+  if (intent === "disconnect-provider") {
+    const provider = formData.get("provider")?.toString();
+    if (provider !== "printful" && provider !== "printify") {
+      return Response.json({ ok: false, message: "Unknown provider." });
+    }
+
+    try {
+      await disconnectProviderConnection({
+        shopId: session.shop,
+        provider,
+      });
+    } catch (error) {
+      if (error instanceof Response) {
+        return Response.json({ ok: false, message: await error.text() });
+      }
+      throw error;
+    }
+
+    return Response.json({ ok: true, message: `${provider === "printify" ? "Printify" : "Printful"} disconnected.` });
+  }
+
+  return Response.json({ ok: false, message: "Unknown action." });
+};
+
+function formatTimestamp(value: string | null) {
+  if (!value) return "Not yet synced";
+  return new Date(value).toLocaleString();
+}
+
 export default function ProviderConnectionsPage() {
-  return <PlaceholderPage title="Provider Connections" />;
+  const { totalVariantCount, variantsWithSkuCount, summaries } = useLoaderData<typeof loader>();
+  const saveFetcher = useFetcher<{ ok: boolean; message: string }>();
+  const disconnectFetcher = useFetcher<{ ok: boolean; message: string }>();
+  const statusRef = useRef<HTMLDivElement>(null);
+  const saveFormRef = useRef<HTMLFormElement>(null);
+  const printify = summaries.find((summary: (typeof summaries)[number]) => summary.provider === "printify");
+  const printful = summaries.find((summary: (typeof summaries)[number]) => summary.provider === "printful");
+
+  const [printifyApiKey, setPrintifyApiKey] = useState("");
+  const [printifyDisplayName, setPrintifyDisplayName] = useState(printify?.displayName ?? "");
+  const [printifyFormError, setPrintifyFormError] = useState<string | null>(null);
+  const saveErrorMessage = printifyFormError ?? (saveFetcher.data && !saveFetcher.data.ok ? saveFetcher.data.message : null);
+  const globalStatus = disconnectFetcher.data ?? (saveFetcher.data?.ok ? saveFetcher.data : null);
+
+  return (
+    <>
+      <ui-title-bar title="Provider Connections" />
+
+      <div
+        ref={statusRef}
+        aria-live="polite"
+        aria-atomic="true"
+        style={{ position: "absolute", width: 1, height: 1, overflow: "hidden", clip: "rect(0,0,0,0)", whiteSpace: "nowrap" }}
+      >
+        {saveErrorMessage ?? globalStatus?.message ?? ""}
+      </div>
+
+      <s-page>
+        <s-section heading="Provider Connections">
+          <div style={{ display: "grid", gap: "0.75rem" }}>
+            <s-text>
+              This page now stores provider configuration state and connection metadata. Full provider sync, live validation,
+              variant mapping, and POD cost resolution are still being built.
+            </s-text>
+            <s-banner tone="info">
+              <s-text>
+                Current scope: save Printify API credentials, review variant SKU coverage, and track provider readiness without
+                pretending sync is already live.
+              </s-text>
+            </s-banner>
+            {saveErrorMessage ? (
+              <s-banner tone="critical">
+                <s-text>{saveErrorMessage}</s-text>
+              </s-banner>
+            ) : null}
+            {globalStatus?.ok ? (
+              <s-banner tone="success">
+                <s-text>{globalStatus.message}</s-text>
+              </s-banner>
+            ) : null}
+          </div>
+        </s-section>
+
+        <s-section heading="Variant readiness">
+          <div style={{ display: "flex", gap: "2rem", flexWrap: "wrap" }}>
+            <div>
+              <div style={{ fontSize: "1.75rem", fontWeight: 650 }}>{totalVariantCount}</div>
+              <s-text>Total variants</s-text>
+            </div>
+            <div>
+              <div style={{ fontSize: "1.75rem", fontWeight: 650 }}>{variantsWithSkuCount}</div>
+              <s-text>Variants with SKU</s-text>
+            </div>
+            <div>
+              <div style={{ fontSize: "1.75rem", fontWeight: 650 }}>{totalVariantCount - variantsWithSkuCount}</div>
+              <s-text>Variants missing SKU</s-text>
+            </div>
+          </div>
+          <div style={{ marginTop: "0.75rem" }}>
+            <s-text>Auto-match will depend on clean SKU coverage. Variants without SKUs will stay unmapped until corrected.</s-text>
+          </div>
+        </s-section>
+
+        <s-section heading="Printify">
+          <div style={{ display: "grid", gap: "1rem" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: "1rem", flexWrap: "wrap" }}>
+              <div style={{ display: "grid", gap: "0.25rem" }}>
+                <strong>Status</strong>
+                <s-text>{printify?.note}</s-text>
+              </div>
+              <s-badge tone={printify?.configured ? "success" : "warning"}>
+                {printify?.configured ? "Configured" : "Not configured"}
+              </s-badge>
+            </div>
+
+            <div style={{ display: "flex", gap: "2rem", flexWrap: "wrap" }}>
+              <div>
+                <strong>Mapped variants</strong>
+                <div>{printify?.mappedVariantCount ?? 0}</div>
+              </div>
+              <div>
+                <strong>Unmapped variants</strong>
+                <div>{printify?.unmappedVariantCount ?? variantsWithSkuCount}</div>
+              </div>
+              <div>
+                <strong>Last sync</strong>
+                <div>{formatTimestamp(printify?.lastSyncedAt ?? null)}</div>
+              </div>
+            </div>
+
+            {printify?.configured ? (
+              <s-banner tone="info">
+                <s-text>
+                  Stored credential hint: {printify.credentialHint ?? "Stored"}. No live validation has run yet.
+                </s-text>
+              </s-banner>
+            ) : null}
+
+            {saveErrorMessage ? (
+              <s-banner tone="critical">
+                <s-text>{saveErrorMessage}</s-text>
+              </s-banner>
+            ) : null}
+
+            <saveFetcher.Form
+              ref={saveFormRef}
+              method="post"
+              onSubmit={(event) => {
+                const trimmedApiKey = printifyApiKey.trim();
+                if (!trimmedApiKey) {
+                  event.preventDefault();
+                  setPrintifyFormError("Printify API key is required.");
+                  return;
+                }
+
+                setPrintifyFormError(null);
+              }}
+            >
+              <input type="hidden" name="intent" value="save-printify-credentials" />
+              <div style={{ display: "grid", gap: "0.75rem" }}>
+                <div style={{ display: "grid", gap: "0.35rem" }}>
+                  <label htmlFor="printify-display-name">Shop label</label>
+                  <input
+                    id="printify-display-name"
+                    name="displayName"
+                    type="text"
+                    value={printifyDisplayName}
+                    onChange={(event) => setPrintifyDisplayName(event.currentTarget.value)}
+                    style={{
+                      width: "100%",
+                      boxSizing: "border-box",
+                      padding: "0.75rem",
+                      borderRadius: "0.75rem",
+                      border: "1px solid var(--p-color-border, #c9cccf)",
+                      background: "var(--p-color-bg-surface, #fff)",
+                      color: "var(--p-color-text, #303030)",
+                      font: "inherit",
+                    }}
+                  />
+                </div>
+                <div style={{ display: "grid", gap: "0.35rem" }}>
+                  <label htmlFor="printify-api-key">API key</label>
+                  <input
+                    id="printify-api-key"
+                    name="apiKey"
+                    type="password"
+                    value={printifyApiKey}
+                    onChange={(event) => {
+                      setPrintifyApiKey(event.currentTarget.value);
+                      if (printifyFormError) {
+                        setPrintifyFormError(null);
+                      }
+                    }}
+                    autoComplete="off"
+                    required
+                    style={{
+                      width: "100%",
+                      boxSizing: "border-box",
+                      padding: "0.75rem",
+                      borderRadius: "0.75rem",
+                      border: "1px solid var(--p-color-border, #c9cccf)",
+                      background: "var(--p-color-bg-surface, #fff)",
+                      color: "var(--p-color-text, #303030)",
+                      font: "inherit",
+                    }}
+                  />
+                </div>
+                <s-text>
+                  Credentials are encrypted before persistence. Saving here records connection readiness only; validation and
+                  sync are still pending.
+                </s-text>
+                <div>
+                  <button
+                    type="button"
+                    disabled={saveFetcher.state !== "idle"}
+                    onClick={() => {
+                      const trimmedApiKey = printifyApiKey.trim();
+                      if (!trimmedApiKey) {
+                        setPrintifyFormError("Printify API key is required.");
+                        return;
+                      }
+
+                      setPrintifyFormError(null);
+                      saveFormRef.current?.requestSubmit();
+                    }}
+                    style={{
+                      appearance: "none",
+                      border: 0,
+                      borderRadius: "999px",
+                      padding: "0.7rem 1.1rem",
+                      background: "var(--p-color-bg-fill-brand, #303030)",
+                      color: "var(--p-color-text-on-color, #fff)",
+                      font: "inherit",
+                      fontWeight: 600,
+                      cursor: saveFetcher.state !== "idle" ? "not-allowed" : "pointer",
+                      opacity: saveFetcher.state !== "idle" ? 0.6 : 1,
+                    }}
+                  >
+                    {printify?.configured ? "Update Printify credentials" : "Save Printify credentials"}
+                  </button>
+                </div>
+              </div>
+            </saveFetcher.Form>
+            {printify?.configured ? (
+              <disconnectFetcher.Form method="post">
+                <input type="hidden" name="intent" value="disconnect-provider" />
+                <input type="hidden" name="provider" value="printify" />
+                <s-button type="submit" variant="secondary" tone="critical" disabled={disconnectFetcher.state !== "idle"}>
+                  Disconnect Printify
+                </s-button>
+              </disconnectFetcher.Form>
+            ) : null}
+          </div>
+        </s-section>
+
+        <s-section heading="Printful">
+          <div style={{ display: "grid", gap: "0.75rem" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: "1rem", flexWrap: "wrap" }}>
+              <div style={{ display: "grid", gap: "0.25rem" }}>
+                <strong>Status</strong>
+                <s-text>{printful?.note}</s-text>
+              </div>
+              <s-badge tone="info">{printful?.configured ? "Configured" : "Planned"}</s-badge>
+            </div>
+            <s-text>
+              Printful OAuth is still deferred. Once it lands, this page will initiate the auth flow and surface the same
+              mapping/sync status shown above for Printify.
+            </s-text>
+          </div>
+        </s-section>
+      </s-page>
+    </>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  console.error("[ProviderConnections] ErrorBoundary caught:", error);
+  return (
+    <>
+      <ui-title-bar title="Provider Connections" />
+      <s-page>
+        <s-banner tone="critical" heading="Provider Connections unavailable">
+          <s-text>Something went wrong loading provider configuration. Please refresh the page.</s-text>
+        </s-banner>
+      </s-page>
+    </>
+  );
 }

--- a/app/routes/ui-fixtures.cart-donation-summary.tsx
+++ b/app/routes/ui-fixtures.cart-donation-summary.tsx
@@ -5,7 +5,13 @@ import { useLoaderData } from "@remix-run/react";
 
 const ASSET_ROOT = path.resolve(process.cwd(), "extensions/count-on-us-product-widget");
 
-type FixtureMode = "default" | "no-donation";
+type FixtureMode = "default" | "mixed-no-cause" | "no-donation";
+type FixtureLine = {
+  productId: string;
+  variantId: string;
+  quantity: number;
+  lineSubtotal?: number;
+};
 
 function buildFixturePayload(mode: FixtureMode) {
   if (mode === "no-donation") {
@@ -27,17 +33,204 @@ function buildFixturePayload(mode: FixtureMode) {
     };
   }
 
+  if (mode === "mixed-no-cause") {
+    return {
+      lines: [
+        {
+          productId: "gid://shopify/Product/1",
+          variantId: "gid://shopify/ProductVariant/1",
+          quantity: 2,
+          lineSubtotal: 40,
+        },
+        {
+          productId: "gid://shopify/Product/2",
+          variantId: "gid://shopify/ProductVariant/2",
+          quantity: 1,
+          lineSubtotal: 15,
+        },
+        {
+          productId: "gid://shopify/Product/3",
+          variantId: "gid://shopify/ProductVariant/3",
+          quantity: 1,
+          lineSubtotal: 30,
+        },
+      ],
+      payloads: {
+        "gid://shopify/Product/1": {
+          productId: "gid://shopify/Product/1",
+          visible: true,
+          variants: [
+            {
+              variantId: "gid://shopify/ProductVariant/1",
+              price: "40.00",
+              currencyCode: "USD",
+              laborCost: "6.00",
+              materialLines: [{ name: "Paper", lineCost: "1.50" }],
+              equipmentLines: [{ name: "Press", lineCost: "0.75" }],
+              shippingMaterialLines: [{ name: "Mailer", lineCost: "0.40" }],
+              podCostTotal: "0.00",
+              mistakeBufferAmount: "0.00",
+              shopifyFees: {
+                processingRate: "2.90",
+                processingFlatFee: "0.30",
+                managedMarketsRate: "0.00",
+                managedMarketsApplicable: false,
+              },
+              causes: [
+                {
+                  causeId: "cause-1",
+                  name: "Neighborhood Arts",
+                  iconUrl: null,
+                  donationPercentage: "100.00",
+                  estimatedDonationAmount: "20.73",
+                  donationCurrencyCode: "USD",
+                  donationLink: "https://example.com/neighborhood-arts",
+                },
+              ],
+              taxReserve: {
+                suppressed: false,
+                estimatedRate: "25.00",
+                estimatedAmount: "6.91",
+              },
+              reconciliation: {
+                estimatedTotal: "40.00",
+                allocatedDonations: "20.73",
+                retainedByShop: "0.00",
+                labor: "6.00",
+                materials: "3.00",
+                equipment: "1.50",
+                packaging: "0.40",
+                pod: "0.00",
+                mistakeBuffer: "0.00",
+                shopifyFees: "1.46",
+                taxReserve: "6.91",
+                remainder: "0.00",
+              },
+            },
+          ],
+        },
+        "gid://shopify/Product/2": {
+          productId: "gid://shopify/Product/2",
+          visible: true,
+          variants: [
+            {
+              variantId: "gid://shopify/ProductVariant/2",
+              price: "15.00",
+              currencyCode: "USD",
+              laborCost: "2.00",
+              materialLines: [{ name: "Ink", lineCost: "2.00" }],
+              equipmentLines: [{ name: "Printer", lineCost: "1.25" }],
+              shippingMaterialLines: [{ name: "Box", lineCost: "0.60" }],
+              podCostTotal: "0.00",
+              mistakeBufferAmount: "0.00",
+              shopifyFees: {
+                processingRate: "2.90",
+                processingFlatFee: "0.30",
+                managedMarketsRate: "0.00",
+                managedMarketsApplicable: false,
+              },
+              causes: [
+                {
+                  causeId: "cause-1",
+                  name: "Neighborhood Arts",
+                  iconUrl: null,
+                  donationPercentage: "50.00",
+                  estimatedDonationAmount: "3.15",
+                  donationCurrencyCode: "USD",
+                  donationLink: "https://example.com/neighborhood-arts",
+                },
+                {
+                  causeId: "cause-2",
+                  name: "Community Library",
+                  iconUrl: null,
+                  donationPercentage: "50.00",
+                  estimatedDonationAmount: "3.16",
+                  donationCurrencyCode: "USD",
+                  donationLink: null,
+                },
+              ],
+              taxReserve: {
+                suppressed: false,
+                estimatedRate: "25.00",
+                estimatedAmount: "2.10",
+              },
+              reconciliation: {
+                estimatedTotal: "15.00",
+                allocatedDonations: "6.31",
+                retainedByShop: "0.00",
+                labor: "2.00",
+                materials: "2.00",
+                equipment: "1.25",
+                packaging: "0.60",
+                pod: "0.00",
+                mistakeBuffer: "0.00",
+                shopifyFees: "0.74",
+                taxReserve: "2.10",
+                remainder: "0.00",
+              },
+            },
+          ],
+        },
+        "gid://shopify/Product/3": {
+          productId: "gid://shopify/Product/3",
+          visible: false,
+          variants: [
+            {
+              variantId: "gid://shopify/ProductVariant/3",
+              price: "30.00",
+              currencyCode: "USD",
+              laborCost: "4.00",
+              materialLines: [{ name: "Canvas", lineCost: "5.00" }],
+              equipmentLines: [{ name: "Cutter", lineCost: "1.00" }],
+              shippingMaterialLines: [{ name: "Sleeve", lineCost: "0.50" }],
+              podCostTotal: "0.00",
+              mistakeBufferAmount: "0.50",
+              shopifyFees: {
+                processingRate: "2.90",
+                processingFlatFee: "0.30",
+                managedMarketsRate: "0.00",
+                managedMarketsApplicable: false,
+              },
+              causes: [],
+              taxReserve: {
+                suppressed: false,
+                estimatedRate: "25.00",
+                estimatedAmount: "4.52",
+              },
+              reconciliation: {
+                estimatedTotal: "30.00",
+                allocatedDonations: "0.00",
+                retainedByShop: "14.03",
+                labor: "4.00",
+                materials: "5.00",
+                equipment: "1.00",
+                packaging: "0.50",
+                pod: "0.00",
+                mistakeBuffer: "0.50",
+                shopifyFees: "0.45",
+                taxReserve: "4.52",
+                remainder: "0.00",
+              },
+            },
+          ],
+        },
+      },
+    };
+  }
+
   return {
     lines: [
       {
         productId: "gid://shopify/Product/1",
         variantId: "gid://shopify/ProductVariant/1",
         quantity: 2,
+        lineSubtotal: 40,
       },
       {
         productId: "gid://shopify/Product/2",
         variantId: "gid://shopify/ProductVariant/2",
         quantity: 1,
+        lineSubtotal: 15,
       },
     ],
     payloads: {
@@ -47,12 +240,12 @@ function buildFixturePayload(mode: FixtureMode) {
         variants: [
           {
             variantId: "gid://shopify/ProductVariant/1",
-            price: "20.00",
+            price: "40.00",
             currencyCode: "USD",
-            laborCost: "3.00",
-            materialLines: [],
-            equipmentLines: [],
-            shippingMaterialLines: [],
+            laborCost: "6.00",
+            materialLines: [{ name: "Paper", lineCost: "1.50" }],
+            equipmentLines: [{ name: "Press", lineCost: "0.75" }],
+            shippingMaterialLines: [{ name: "Mailer", lineCost: "0.40" }],
             podCostTotal: "0.00",
             mistakeBufferAmount: "0.00",
             shopifyFees: {
@@ -67,7 +260,7 @@ function buildFixturePayload(mode: FixtureMode) {
                 name: "Neighborhood Arts",
                 iconUrl: null,
                 donationPercentage: "100.00",
-                estimatedDonationAmount: "5.00",
+                estimatedDonationAmount: "20.73",
                 donationCurrencyCode: "USD",
                 donationLink: "https://example.com/neighborhood-arts",
               },
@@ -75,7 +268,21 @@ function buildFixturePayload(mode: FixtureMode) {
             taxReserve: {
               suppressed: false,
               estimatedRate: "25.00",
-              estimatedAmount: "1.00",
+              estimatedAmount: "6.91",
+            },
+            reconciliation: {
+              estimatedTotal: "40.00",
+              allocatedDonations: "20.73",
+              retainedByShop: "0.00",
+              labor: "6.00",
+              materials: "3.00",
+              equipment: "1.50",
+              packaging: "0.40",
+              pod: "0.00",
+              mistakeBuffer: "0.00",
+              shopifyFees: "1.46",
+              taxReserve: "6.91",
+              remainder: "0.00",
             },
           },
         ],
@@ -89,9 +296,9 @@ function buildFixturePayload(mode: FixtureMode) {
             price: "15.00",
             currencyCode: "USD",
             laborCost: "2.00",
-            materialLines: [],
-            equipmentLines: [],
-            shippingMaterialLines: [],
+            materialLines: [{ name: "Ink", lineCost: "2.00" }],
+            equipmentLines: [{ name: "Printer", lineCost: "1.25" }],
+            shippingMaterialLines: [{ name: "Box", lineCost: "0.60" }],
             podCostTotal: "0.00",
             mistakeBufferAmount: "0.00",
             shopifyFees: {
@@ -106,7 +313,7 @@ function buildFixturePayload(mode: FixtureMode) {
                 name: "Neighborhood Arts",
                 iconUrl: null,
                 donationPercentage: "50.00",
-                estimatedDonationAmount: "3.00",
+                estimatedDonationAmount: "3.15",
                 donationCurrencyCode: "USD",
                 donationLink: "https://example.com/neighborhood-arts",
               },
@@ -115,7 +322,7 @@ function buildFixturePayload(mode: FixtureMode) {
                 name: "Community Library",
                 iconUrl: null,
                 donationPercentage: "50.00",
-                estimatedDonationAmount: "3.00",
+                estimatedDonationAmount: "3.16",
                 donationCurrencyCode: "USD",
                 donationLink: null,
               },
@@ -123,7 +330,21 @@ function buildFixturePayload(mode: FixtureMode) {
             taxReserve: {
               suppressed: false,
               estimatedRate: "25.00",
-              estimatedAmount: "1.00",
+              estimatedAmount: "2.10",
+            },
+            reconciliation: {
+              estimatedTotal: "15.00",
+              allocatedDonations: "6.31",
+              retainedByShop: "0.00",
+              labor: "2.00",
+              materials: "2.00",
+              equipment: "1.25",
+              packaging: "0.60",
+              pod: "0.00",
+              mistakeBuffer: "0.00",
+              shopifyFees: "0.74",
+              taxReserve: "2.10",
+              remainder: "0.00",
             },
           },
         ],
@@ -134,7 +355,9 @@ function buildFixturePayload(mode: FixtureMode) {
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const url = new URL(request.url);
-  const mode = url.searchParams.get("mode") === "no-donation" ? "no-donation" : "default";
+  const rawMode = url.searchParams.get("mode");
+  const mode: FixtureMode =
+    rawMode === "no-donation" ? "no-donation" : rawMode === "mixed-no-cause" ? "mixed-no-cause" : "default";
 
   const [css, script] = await Promise.all([
     readFile(path.join(ASSET_ROOT, "assets", "donation-widget.css"), "utf8"),
@@ -154,11 +377,31 @@ export default function CartDonationSummaryFixtureRoute() {
 
   const fetchShim = `
     window.__COUNT_ON_US_FIXTURE__ = ${JSON.stringify(fixture)};
+    window.__COUNT_ON_US_FIXTURE_UNIT_PRICES__ = Object.fromEntries(
+      window.__COUNT_ON_US_FIXTURE__.lines.map((line, index) => [
+        index,
+        line.lineSubtotal != null && line.quantity ? Number(line.lineSubtotal) / Number(line.quantity) : 0,
+      ]),
+    );
     const originalFetch = window.fetch.bind(window);
     window.fetch = async (input, init) => {
       const url = typeof input === "string" ? input : input.url;
       const prefix = "/apps/count-on-us/products/";
+      if (url.includes("/cart.js")) {
+        const items = window.__COUNT_ON_US_FIXTURE__.lines.map((line) => ({
+          product_id: Number(String(line.productId).split("/").pop()),
+          variant_id: Number(String(line.variantId).split("/").pop()),
+          quantity: line.quantity,
+          final_line_price: Math.round(Number(line.lineSubtotal || 0) * 100),
+        }));
+
+        return new Response(JSON.stringify({ items }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
       if (url.includes(prefix)) {
+        const parsedUrl = new URL(url, window.location.origin);
         const encodedProductId = url.split(prefix)[1].split("?")[0];
         const productId = decodeURIComponent(encodedProductId);
         const payload = window.__COUNT_ON_US_FIXTURE__.payloads[productId];
@@ -169,7 +412,17 @@ export default function CartDonationSummaryFixtureRoute() {
           });
         }
 
-        return new Response(JSON.stringify({ ok: true, data: payload }), {
+        const data =
+          parsedUrl.searchParams.get("metadataOnly") === "1"
+            ? {
+                productId: payload.productId,
+                deliveryMode: "preload",
+                visible: payload.visible,
+                totalLineItemCount: payload.variants[0]?.materialLines?.length ?? 0,
+              }
+            : payload;
+
+        return new Response(JSON.stringify({ ok: true, data }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         });
@@ -194,36 +447,69 @@ export default function CartDonationSummaryFixtureRoute() {
             Mode: <strong>{mode}</strong>
           </p>
 
-          <div
-            className="count-on-us-widget"
-            data-count-on-us-cart-summary
-            data-proxy-base="/apps/count-on-us"
-            data-count-on-us-cart-lines-json={encodeURIComponent(JSON.stringify(fixture.lines))}
-          >
-            <div className="count-on-us-widget__header">
-              <h3 className="count-on-us-widget__heading">See your donation impact</h3>
-              <p className="count-on-us-widget__description">
-                Open a cart-level view of the estimated donation totals across the causes in your cart.
-              </p>
-            </div>
+          <section style={{ display: "grid", gap: "0.75rem" }}>
+            {(fixture.lines as FixtureLine[]).map((line, index) => (
+              <article
+                key={`${line.productId}-${index}`}
+                className="cart-item"
+                style={{
+                  display: "grid",
+                  gap: "0.35rem",
+                  padding: "0.85rem 1rem",
+                  borderRadius: "14px",
+                  background: "#ffffff",
+                  border: "1px solid rgba(17, 24, 39, 0.08)",
+                }}
+              >
+                <div style={{ display: "flex", justifyContent: "space-between", gap: "1rem", alignItems: "baseline" }}>
+                  <a href={`/products/fixture-${index + 1}`} style={{ color: "#111827", fontWeight: 600, textDecoration: "none" }}>
+                    Fixture cart item {index + 1}
+                  </a>
+                  <span data-fixture-qty style={{ color: "#6b7280", fontSize: "0.92rem" }}>
+                    Qty {line.quantity}
+                  </span>
+                </div>
+                <label style={{ display: "grid", gap: "0.25rem", maxWidth: "6rem" }}>
+                  <span style={{ color: "#6b7280", fontSize: "0.82rem" }}>Quantity</span>
+                  <input name="updates[]" type="number" defaultValue={line.quantity} min="0" />
+                </label>
+              </article>
+            ))}
+          </section>
 
-            <button
-              type="button"
-              className="count-on-us-widget__toggle"
-              data-count-on-us-cart-trigger
-              aria-haspopup="dialog"
-              aria-expanded="false"
+          {mode === "no-donation" ? (
+            <p style={{ margin: 0, color: "#6b7280" }}>No donation-linked items in this fixture cart.</p>
+          ) : (
+            <div
+              className="count-on-us-widget count-on-us-widget--cart-summary"
+              data-count-on-us-cart-summary
+              data-proxy-base="/apps/count-on-us"
+              data-count-on-us-cart-lines-json={encodeURIComponent(JSON.stringify(fixture.lines))}
             >
-              <span>See your donation impact</span>
-              <span aria-hidden="true">+</span>
-            </button>
+              <div className="count-on-us-widget__header">
+                <h3 className="count-on-us-widget__heading">Your purchase is making a difference!</h3>
+                <p className="count-on-us-widget__description">
+                  Open a cart-level view of the causes your purchase supports and how the estimate is calculated.
+                </p>
+              </div>
 
-            <script
-              type="application/json"
-              data-count-on-us-cart-lines
-              dangerouslySetInnerHTML={{ __html: JSON.stringify(fixture.lines) }}
-            />
-          </div>
+              <button
+                type="button"
+                className="count-on-us-widget__toggle"
+                data-count-on-us-cart-trigger
+                aria-haspopup="dialog"
+                aria-expanded="false"
+              >
+                <span>See donation details</span>
+              </button>
+
+              <script
+                type="application/json"
+                data-count-on-us-cart-lines
+                dangerouslySetInnerHTML={{ __html: JSON.stringify(fixture.lines) }}
+              />
+            </div>
+          )}
 
           <button type="button">Focusable control after widget</button>
         </main>
@@ -233,6 +519,27 @@ export default function CartDonationSummaryFixtureRoute() {
         <script
           dangerouslySetInnerHTML={{
             __html: `
+              document.querySelectorAll('.cart-item input[name="updates[]"]').forEach((input, index) => {
+                input.addEventListener('input', (event) => {
+                  const target = event.currentTarget;
+                  const quantity = Math.max(0, Number.parseInt(target.value || '0', 10) || 0);
+                  const unitPrice = window.__COUNT_ON_US_FIXTURE_UNIT_PRICES__[index] || 0;
+
+                  if (quantity === 0) {
+                    window.__COUNT_ON_US_FIXTURE__.lines.splice(index, 1);
+                    target.closest('.cart-item')?.remove();
+                    return;
+                  }
+
+                  const line = window.__COUNT_ON_US_FIXTURE__.lines[index];
+                  if (!line) return;
+                  line.quantity = quantity;
+                  line.lineSubtotal = Number((unitPrice * quantity).toFixed(2));
+                  const qtyNode = target.closest('.cart-item')?.querySelector('[data-fixture-qty]');
+                  if (qtyNode) qtyNode.textContent = 'Qty ' + quantity;
+                });
+              });
+
               document.dispatchEvent(new Event("DOMContentLoaded", { bubbles: true }));
             `,
           }}

--- a/app/routes/ui-fixtures.product-donation-widget.tsx
+++ b/app/routes/ui-fixtures.product-donation-widget.tsx
@@ -1,0 +1,249 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+
+const ASSET_ROOT = path.resolve(process.cwd(), "extensions/count-on-us-product-widget");
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const url = new URL(request.url);
+  const [css, script] = await Promise.all([
+    readFile(path.join(ASSET_ROOT, "assets", "donation-widget.css"), "utf8"),
+    readFile(path.join(ASSET_ROOT, "assets", "product-donation-widget.js"), "utf8"),
+  ]);
+
+  const payload = {
+    productId: "gid://shopify/Product/1",
+    deliveryMode: "preload",
+    visible: true,
+    totalLineItemCount: 12,
+    variants: [
+      {
+        variantId: "gid://shopify/ProductVariant/101",
+        price: "20.00",
+        currencyCode: "USD",
+        laborCost: "3.00",
+        materialLines: [{ name: "Paper", type: "production", lineCost: "2.00" }],
+        equipmentLines: [{ name: "Press", lineCost: "1.00" }],
+        shippingMaterialLines: [{ name: "Mailer", lineCost: "0.50" }],
+        podCostTotal: "0.00",
+        mistakeBufferAmount: "0.50",
+        shopifyFees: {
+          processingRate: "2.90",
+          processingFlatFee: "0.30",
+          managedMarketsRate: "0.00",
+          managedMarketsApplicable: false,
+        },
+        causes: [
+          {
+            causeId: "cause-1",
+            name: "Neighborhood Arts",
+            iconUrl: null,
+            donationPercentage: "100.00",
+            estimatedDonationAmount: "4.00",
+            donationCurrencyCode: "USD",
+            donationLink: "https://example.com/neighborhood-arts",
+          },
+        ],
+        taxReserve: {
+          suppressed: false,
+          estimatedRate: "25.00",
+          estimatedAmount: "1.00",
+        },
+      },
+      {
+        variantId: "gid://shopify/ProductVariant/202",
+        price: "35.00",
+        currencyCode: "USD",
+        laborCost: "5.00",
+        materialLines: [{ name: "Canvas", type: "production", lineCost: "4.00" }],
+        equipmentLines: [{ name: "Printer", lineCost: "2.00" }],
+        shippingMaterialLines: [{ name: "Tube", lineCost: "1.25" }],
+        podCostTotal: "0.00",
+        mistakeBufferAmount: "0.75",
+        shopifyFees: {
+          processingRate: "2.90",
+          processingFlatFee: "0.30",
+          managedMarketsRate: "0.00",
+          managedMarketsApplicable: false,
+        },
+        causes: [
+          {
+            causeId: "cause-2",
+            name: "Community Library",
+            iconUrl: null,
+            donationPercentage: "100.00",
+            estimatedDonationAmount: "8.00",
+            donationCurrencyCode: "USD",
+            donationLink: null,
+          },
+        ],
+        taxReserve: {
+          suppressed: false,
+          estimatedRate: "25.00",
+          estimatedAmount: "2.00",
+        },
+      },
+    ],
+  };
+
+  return Response.json({
+    host: url.host,
+    css,
+    script,
+    payload,
+  });
+};
+
+export default function ProductDonationWidgetFixtureRoute() {
+  const { host, css, script, payload } = useLoaderData<typeof loader>();
+
+  const fetchShim = `
+    const fixturePayload = ${JSON.stringify(payload)};
+    const expectedMetadataPath = "/apps/count-on-us/products/" + encodeURIComponent(fixturePayload.productId) + "?metadataOnly=1";
+    const expectedPayloadPath = "/apps/count-on-us/products/" + encodeURIComponent(fixturePayload.productId);
+    const originalFetch = window.fetch.bind(window);
+    window.fetch = async (input, init) => {
+      const requestUrl = new URL(typeof input === "string" ? input : input.url, window.location.origin);
+      const pathWithQuery = requestUrl.pathname + requestUrl.search;
+      if (pathWithQuery === expectedMetadataPath) {
+        return new Response(JSON.stringify({
+          data: {
+            productId: fixturePayload.productId,
+            deliveryMode: fixturePayload.deliveryMode,
+            visible: fixturePayload.visible,
+            totalLineItemCount: fixturePayload.totalLineItemCount
+          }
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      if (pathWithQuery === expectedPayloadPath) {
+        return new Response(JSON.stringify({ data: fixturePayload }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return originalFetch(input, init);
+    };
+  `;
+
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Product Donation Widget Fixture</title>
+        <style dangerouslySetInnerHTML={{ __html: css }} />
+      </head>
+      <body style={{ fontFamily: "system-ui, sans-serif", background: "#f6f3eb", margin: 0, padding: "2rem" }}>
+        <main style={{ maxWidth: "48rem", margin: "0 auto", display: "grid", gap: "1rem" }}>
+          <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Product donation widget fixture</h1>
+          <form action="/cart/add" method="post" style={{ display: "grid", gap: "0.75rem" }}>
+            <label style={{ display: "grid", gap: "0.35rem" }}>
+              <span>Variant</span>
+              <select name="id" defaultValue="101">
+                <option value="101">Sticker</option>
+                <option value="202">Canvas print</option>
+              </select>
+            </label>
+            <label style={{ display: "grid", gap: "0.35rem" }}>
+              <span>Quantity</span>
+              <input name="quantity" type="number" min="1" defaultValue="1" />
+            </label>
+
+            <div
+              className="count-on-us-widget"
+              data-count-on-us-widget
+              data-product-id="gid://shopify/Product/1"
+              data-selected-variant-id="gid://shopify/ProductVariant/101"
+              data-selected-quantity="1"
+              data-proxy-base="/apps/count-on-us"
+            >
+              <div className="count-on-us-widget__header">
+                <h3 className="count-on-us-widget__heading">See your donation impact</h3>
+                <p className="count-on-us-widget__description">
+                  Preview the cost breakdown, estimated donation by cause, and estimated tax reserve for this product.
+                </p>
+              </div>
+
+              <button
+                type="button"
+                className="count-on-us-widget__toggle"
+                data-count-on-us-toggle
+                aria-expanded="false"
+                aria-controls="count-on-us-widget-panel-fixture"
+              >
+                <span>See how we calculate this</span>
+                <span aria-hidden="true">+</span>
+              </button>
+
+              <div
+                id="count-on-us-widget-panel-fixture"
+                className="count-on-us-widget__panel"
+                data-count-on-us-panel
+                hidden
+              ></div>
+
+              <div className="count-on-us-widget__visually-hidden" aria-live="polite" data-count-on-us-live></div>
+            </div>
+          </form>
+          <p style={{ margin: 0, color: "#4b5563" }}>Host: {host}</p>
+        </main>
+
+        <script dangerouslySetInnerHTML={{ __html: fetchShim }} />
+        <script dangerouslySetInnerHTML={{ __html: script }} />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              window.__COUNT_ON_US_PRODUCT_WIDGET_READY__ = false;
+              window.__COUNT_ON_US_PRODUCT_WIDGET_OPEN__ = false;
+
+              const markReady = () => {
+                const widget = document.querySelector("[data-count-on-us-widget]");
+                if (!widget) return false;
+
+                if (widget.dataset.widgetInteractive === "true" && widget.dataset.widgetBound === "true") {
+                  window.__COUNT_ON_US_PRODUCT_WIDGET_READY__ = true;
+                  return true;
+                }
+
+                return false;
+              };
+
+              const triggerBoot = () => {
+                document.dispatchEvent(new Event("DOMContentLoaded", { bubbles: true }));
+                window.dispatchEvent(new Event("load"));
+              };
+
+              const openWidget = () => {
+                const toggle = document.querySelector("[data-count-on-us-toggle]");
+                const panel = document.querySelector("[data-count-on-us-panel]");
+                if (!toggle || !panel) return false;
+
+                if (toggle.getAttribute("aria-expanded") !== "true") {
+                  toggle.click();
+                }
+
+                if (toggle.getAttribute("aria-expanded") === "true" && !panel.hidden) {
+                  window.__COUNT_ON_US_PRODUCT_WIDGET_OPEN__ = true;
+                  return true;
+                }
+
+                return false;
+              };
+
+              triggerBoot();
+
+              const ensureReady = () => {
+                if (markReady() && openWidget()) return;
+                triggerBoot();
+                window.setTimeout(ensureReady, 50);
+              };
+
+              ensureReady();
+            `,
+          }}
+        />
+      </body>
+    </html>
+  );
+}

--- a/app/routes/ui-fixtures.product-donation-widget.tsx
+++ b/app/routes/ui-fixtures.product-donation-widget.tsx
@@ -50,6 +50,20 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
           estimatedRate: "25.00",
           estimatedAmount: "1.00",
         },
+        reconciliation: {
+          estimatedTotal: "20.00",
+          allocatedDonations: "4.00",
+          retainedByShop: "5.97",
+          labor: "3.00",
+          materials: "2.00",
+          equipment: "1.00",
+          packaging: "0.50",
+          pod: "0.00",
+          mistakeBuffer: "0.50",
+          shopifyFees: "2.03",
+          taxReserve: "1.00",
+          remainder: "0.00",
+        },
       },
       {
         variantId: "gid://shopify/ProductVariant/202",
@@ -83,6 +97,20 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
           estimatedRate: "25.00",
           estimatedAmount: "2.00",
         },
+        reconciliation: {
+          estimatedTotal: "35.00",
+          allocatedDonations: "8.00",
+          retainedByShop: "11.93",
+          labor: "5.00",
+          materials: "4.00",
+          equipment: "2.00",
+          packaging: "1.25",
+          pod: "0.00",
+          mistakeBuffer: "0.75",
+          shopifyFees: "2.07",
+          taxReserve: "2.00",
+          remainder: "0.00",
+        },
       },
     ],
   };
@@ -100,27 +128,34 @@ export default function ProductDonationWidgetFixtureRoute() {
 
   const fetchShim = `
     const fixturePayload = ${JSON.stringify(payload)};
-    const expectedMetadataPath = "/apps/count-on-us/products/" + encodeURIComponent(fixturePayload.productId) + "?metadataOnly=1";
-    const expectedPayloadPath = "/apps/count-on-us/products/" + encodeURIComponent(fixturePayload.productId);
     const originalFetch = window.fetch.bind(window);
     window.fetch = async (input, init) => {
       const requestUrl = new URL(typeof input === "string" ? input : input.url, window.location.origin);
-      const pathWithQuery = requestUrl.pathname + requestUrl.search;
-      if (pathWithQuery === expectedMetadataPath) {
+      const prefix = "/apps/count-on-us/products/";
+      if (requestUrl.pathname.startsWith(prefix)) {
+        const encodedProductId = requestUrl.pathname.slice(prefix.length);
+        const productId = decodeURIComponent(encodedProductId);
+        if (productId !== fixturePayload.productId) {
+          return new Response(JSON.stringify({ ok: false, message: "Missing fixture payload" }), {
+            status: 404,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+
+        if (requestUrl.searchParams.get("metadataOnly") === "1") {
+          return new Response(JSON.stringify({
+            data: {
+              productId: fixturePayload.productId,
+              deliveryMode: fixturePayload.deliveryMode,
+              visible: fixturePayload.visible,
+              totalLineItemCount: fixturePayload.totalLineItemCount
+            }
+          }), { status: 200, headers: { "Content-Type": "application/json" } });
+        }
+
         return new Response(JSON.stringify({
-          data: {
-            productId: fixturePayload.productId,
-            deliveryMode: fixturePayload.deliveryMode,
-            visible: fixturePayload.visible,
-            totalLineItemCount: fixturePayload.totalLineItemCount
-          }
+          data: fixturePayload
         }), { status: 200, headers: { "Content-Type": "application/json" } });
-      }
-      if (pathWithQuery === expectedPayloadPath) {
-        return new Response(JSON.stringify({ data: fixturePayload }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        });
       }
       return originalFetch(input, init);
     };

--- a/app/routes/ui-fixtures.products-bootstrap.tsx
+++ b/app/routes/ui-fixtures.products-bootstrap.tsx
@@ -1,0 +1,55 @@
+import type { LoaderFunctionArgs } from "@remix-run/node";
+
+import { prisma } from "../db.server";
+
+const shopId = "playwright-products-sync.myshopify.com";
+const shopifyDomain = "playwright-products-sync.myshopify.com";
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const url = new URL(request.url);
+  const baseUrl = `${url.protocol}//${url.host}`;
+
+  await prisma.auditLog.deleteMany({
+    where: {
+      shopId,
+      action: {
+        in: ["CATALOG_SYNC_REQUESTED", "CATALOG_SYNC_COMPLETED"],
+      },
+    },
+  });
+
+  await prisma.product.deleteMany({ where: { shopId } });
+
+  await prisma.shop.upsert({
+    where: { shopId },
+    update: {
+      shopifyDomain,
+      currency: "USD",
+      catalogSynced: true,
+    },
+    create: {
+      shopId,
+      shopifyDomain,
+      currency: "USD",
+      catalogSynced: true,
+    },
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      shopId,
+      entity: "Shop",
+      action: "CATALOG_SYNC_COMPLETED",
+      actor: "system",
+      payload: {
+        productCount: 2,
+        variantCount: 3,
+      },
+      createdAt: new Date("2026-04-09T12:00:00Z"),
+    },
+  });
+
+  return Response.json({
+    productsUrl: `${baseUrl}/app/products?__playwrightShop=${encodeURIComponent(shopId)}`,
+  });
+};

--- a/app/routes/ui-fixtures.provider-connections-bootstrap.tsx
+++ b/app/routes/ui-fixtures.provider-connections-bootstrap.tsx
@@ -1,0 +1,91 @@
+import type { LoaderFunctionArgs } from "@remix-run/node";
+
+import { prisma } from "../db.server";
+
+const shopId = "playwright-provider-connections.myshopify.com";
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const url = new URL(request.url);
+  const baseUrl = `${url.protocol}//${url.host}`;
+
+  await prisma.providerCostCache.deleteMany({
+    where: {
+      mapping: {
+        shopId,
+      },
+    },
+  });
+
+  await prisma.providerVariantMapping.deleteMany({
+    where: { shopId },
+  });
+
+  await prisma.providerConnection.deleteMany({
+    where: { shopId },
+  });
+
+  await prisma.variantCostConfig.deleteMany({
+    where: { shopId },
+  });
+
+  await prisma.variant.deleteMany({
+    where: { shopId },
+  });
+
+  await prisma.product.deleteMany({
+    where: { shopId },
+  });
+
+  await prisma.shop.upsert({
+    where: { shopId },
+    update: {
+      shopifyDomain: shopId,
+      currency: "USD",
+      catalogSynced: true,
+    },
+    create: {
+      shopId,
+      shopifyDomain: shopId,
+      currency: "USD",
+      catalogSynced: true,
+    },
+  });
+
+  const product = await prisma.product.create({
+    data: {
+      shopId,
+      shopifyId: "gid://shopify/Product/9100",
+      title: "Provider Fixture Product",
+      handle: "provider-fixture-product",
+      status: "active",
+      syncedAt: new Date("2026-04-09T12:00:00Z"),
+    },
+  });
+
+  await prisma.variant.createMany({
+    data: [
+      {
+        shopId,
+        productId: product.id,
+        shopifyId: "gid://shopify/ProductVariant/9101",
+        title: "Mapped-ready Variant",
+        sku: "SKU-READY-001",
+        price: "24.00",
+        syncedAt: new Date("2026-04-09T12:00:00Z"),
+      },
+      {
+        shopId,
+        productId: product.id,
+        shopifyId: "gid://shopify/ProductVariant/9102",
+        title: "Missing SKU Variant",
+        sku: null,
+        price: "26.00",
+        syncedAt: new Date("2026-04-09T12:00:00Z"),
+      },
+    ],
+  });
+
+  return Response.json({
+    providerConnectionsUrl: `${baseUrl}/app/provider-connections?__playwrightShop=${shopId}`,
+  });
+};

--- a/app/routes/ui-fixtures.setup-wizard-bootstrap.tsx
+++ b/app/routes/ui-fixtures.setup-wizard-bootstrap.tsx
@@ -30,6 +30,7 @@ export const loader = async () => {
       shopifyDomain: FIXTURE_SHOP,
       catalogSynced: true,
       paymentRate: new Prisma.Decimal("0.0290"),
+      managedMarketsEnableDate: null,
       wizardStep: 0,
     },
     create: {
@@ -38,6 +39,7 @@ export const loader = async () => {
       currency: "USD",
       catalogSynced: true,
       paymentRate: new Prisma.Decimal("0.0290"),
+      managedMarketsEnableDate: null,
       wizardStep: 0,
     },
   });

--- a/app/services/providerConnections.server.test.ts
+++ b/app/services/providerConnections.server.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  disconnectProviderConnection,
+  getProviderConnectionsPageData,
+  savePrintifyConnection,
+} from "./providerConnections.server";
+
+describe("providerConnections.server", () => {
+  it("summarizes configured and unconfigured providers", async () => {
+    const db = {
+      providerConnection: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            provider: "printify",
+            authType: "api_key",
+            status: "configured",
+            displayName: "Fixture Shop",
+            credentialHint: "****1234",
+            lastSyncedAt: null,
+            updatedAt: new Date("2026-04-09T18:00:00Z"),
+            _count: {
+              mappings: 2,
+            },
+          },
+        ]),
+      },
+      variant: {
+        count: vi.fn().mockResolvedValueOnce(5).mockResolvedValueOnce(4),
+      },
+      providerVariantMapping: {},
+      auditLog: {},
+    };
+
+    const result = await getProviderConnectionsPageData("fixture.myshopify.com", db as never);
+
+    expect(result.totalVariantCount).toBe(5);
+    expect(result.variantsWithSkuCount).toBe(4);
+    expect(result.summaries.find((summary) => summary.provider === "printify")?.configured).toBe(true);
+    expect(result.summaries.find((summary) => summary.provider === "printify")?.unmappedVariantCount).toBe(2);
+    expect(result.summaries.find((summary) => summary.provider === "printful")?.configured).toBe(false);
+  });
+
+  it("stores encrypted Printify credentials", async () => {
+    vi.stubEnv("PROVIDER_CREDENTIALS_SECRET", "provider-test-secret");
+
+    const upsert = vi.fn().mockResolvedValue({ id: "connection_1" });
+    const createAudit = vi.fn().mockResolvedValue(undefined);
+    const db = {
+      providerConnection: {
+        upsert,
+      },
+      providerVariantMapping: {},
+      variant: {},
+      auditLog: {
+        create: createAudit,
+      },
+    };
+
+    await savePrintifyConnection(
+      {
+        shopId: "fixture.myshopify.com",
+        apiKey: "pk_live_fixture_printify_key_1234",
+        displayName: "Fixture Shop",
+      },
+      db as never,
+    );
+
+    expect(upsert).toHaveBeenCalledOnce();
+    const upsertArgs = upsert.mock.calls[0]?.[0];
+    expect(upsertArgs.update.credentialHint).toBe("****1234");
+    expect(upsertArgs.update.credentialsEncrypted).not.toContain("pk_live_fixture_printify_key_1234");
+    expect(createAudit).toHaveBeenCalledOnce();
+  });
+
+  it("disconnects a saved provider connection", async () => {
+    const findUnique = vi.fn().mockResolvedValue({ id: "connection_1" });
+    const deleteConnection = vi.fn().mockResolvedValue(undefined);
+    const createAudit = vi.fn().mockResolvedValue(undefined);
+    const db = {
+      providerConnection: {
+        findUnique,
+        delete: deleteConnection,
+      },
+      providerVariantMapping: {},
+      variant: {},
+      auditLog: {
+        create: createAudit,
+      },
+    };
+
+    await disconnectProviderConnection(
+      {
+        shopId: "fixture.myshopify.com",
+        provider: "printify",
+      },
+      db as never,
+    );
+
+    expect(findUnique).toHaveBeenCalledOnce();
+    expect(deleteConnection).toHaveBeenCalledOnce();
+    expect(createAudit).toHaveBeenCalledOnce();
+  });
+});

--- a/app/services/providerConnections.server.ts
+++ b/app/services/providerConnections.server.ts
@@ -1,0 +1,223 @@
+import { prisma } from "../db.server";
+import { encryptProviderCredential } from "./providerCredentials.server";
+
+type ProviderDbClient = Pick<
+  typeof prisma,
+  "providerConnection" | "providerVariantMapping" | "variant" | "auditLog"
+>;
+
+export type ProviderConnectionSummary = {
+  provider: "printful" | "printify";
+  authType: "oauth" | "api_key";
+  status: "not_configured" | "configured";
+  configured: boolean;
+  displayName: string | null;
+  credentialHint: string | null;
+  lastSyncedAt: string | null;
+  updatedAt: string | null;
+  mappedVariantCount: number;
+  unmappedVariantCount: number;
+  note: string;
+};
+
+export type ProviderConnectionsPageData = {
+  totalVariantCount: number;
+  variantsWithSkuCount: number;
+  summaries: ProviderConnectionSummary[];
+};
+
+function toIsoString(value: Date | null | undefined) {
+  return value ? value.toISOString() : null;
+}
+
+function maskApiKey(apiKey: string) {
+  const trimmed = apiKey.trim();
+  const suffix = trimmed.slice(-4);
+  return suffix ? `****${suffix}` : "Stored";
+}
+
+export async function getProviderConnectionsPageData(
+  shopId: string,
+  db: ProviderDbClient = prisma,
+): Promise<ProviderConnectionsPageData> {
+  const [connections, totalVariantCount, variantsWithSkuCount] = await Promise.all([
+    db.providerConnection.findMany({
+      where: { shopId },
+      select: {
+        provider: true,
+        authType: true,
+        status: true,
+        displayName: true,
+        credentialHint: true,
+        lastSyncedAt: true,
+        updatedAt: true,
+        _count: {
+          select: {
+            mappings: true,
+          },
+        },
+      },
+      orderBy: { provider: "asc" },
+    }),
+    db.variant.count({ where: { shopId } }),
+    db.variant.count({
+      where: {
+        shopId,
+        sku: {
+          not: null,
+        },
+      },
+    }),
+  ]);
+
+  const connectionMap = new Map(connections.map((connection) => [connection.provider, connection]));
+
+  const summaries: ProviderConnectionSummary[] = [
+    {
+      provider: "printful",
+      authType: "oauth",
+      status: connectionMap.has("printful") ? "configured" : "not_configured",
+      configured: connectionMap.has("printful"),
+      displayName: connectionMap.get("printful")?.displayName ?? null,
+      credentialHint: connectionMap.get("printful")?.credentialHint ?? null,
+      lastSyncedAt: toIsoString(connectionMap.get("printful")?.lastSyncedAt),
+      updatedAt: toIsoString(connectionMap.get("printful")?.updatedAt),
+      mappedVariantCount: connectionMap.get("printful")?._count.mappings ?? 0,
+      unmappedVariantCount: Math.max(variantsWithSkuCount - (connectionMap.get("printful")?._count.mappings ?? 0), 0),
+      note: "Printful OAuth is not wired yet. This page will expose that flow in a later provider tranche.",
+    },
+    {
+      provider: "printify",
+      authType: "api_key",
+      status: connectionMap.has("printify") ? "configured" : "not_configured",
+      configured: connectionMap.has("printify"),
+      displayName: connectionMap.get("printify")?.displayName ?? null,
+      credentialHint: connectionMap.get("printify")?.credentialHint ?? null,
+      lastSyncedAt: toIsoString(connectionMap.get("printify")?.lastSyncedAt),
+      updatedAt: toIsoString(connectionMap.get("printify")?.updatedAt),
+      mappedVariantCount: connectionMap.get("printify")?._count.mappings ?? 0,
+      unmappedVariantCount: Math.max(variantsWithSkuCount - (connectionMap.get("printify")?._count.mappings ?? 0), 0),
+      note:
+        "Printify API keys can be stored now. Live validation, variant matching, and cost sync are still pending.",
+    },
+  ];
+
+  return {
+    totalVariantCount,
+    variantsWithSkuCount,
+    summaries,
+  };
+}
+
+export async function savePrintifyConnection(
+  input: {
+    shopId: string;
+    apiKey: string;
+    displayName?: string | null;
+  },
+  db: ProviderDbClient = prisma,
+): Promise<{ id: string }> {
+  const apiKey = input.apiKey.trim();
+  if (!apiKey) {
+    throw new Response("Printify API key is required.", { status: 400 });
+  }
+
+  if (apiKey.length < 8) {
+    throw new Response("Printify API key looks too short.", { status: 400 });
+  }
+
+  const displayName = input.displayName?.trim() || null;
+  const credentialsEncrypted = encryptProviderCredential(apiKey);
+  const credentialHint = maskApiKey(apiKey);
+
+  const connection = await db.providerConnection.upsert({
+    where: {
+      shopId_provider: {
+        shopId: input.shopId,
+        provider: "printify",
+      },
+    },
+    update: {
+      authType: "api_key",
+      status: "configured",
+      displayName,
+      credentialsEncrypted,
+      credentialHint,
+    },
+    create: {
+      shopId: input.shopId,
+      provider: "printify",
+      authType: "api_key",
+      status: "configured",
+      displayName,
+      credentialsEncrypted,
+      credentialHint,
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  await db.auditLog.create({
+    data: {
+      shopId: input.shopId,
+      entity: "ProviderConnection",
+      entityId: connection.id,
+      action: "PRINTIFY_CONNECTION_CONFIGURED",
+      actor: "merchant",
+      payload: {
+        provider: "printify",
+        status: "configured",
+        displayName,
+      },
+    },
+  });
+
+  return connection;
+}
+
+export async function disconnectProviderConnection(
+  input: {
+    shopId: string;
+    provider: "printful" | "printify";
+  },
+  db: ProviderDbClient = prisma,
+): Promise<void> {
+  const existing = await db.providerConnection.findUnique({
+    where: {
+      shopId_provider: {
+        shopId: input.shopId,
+        provider: input.provider,
+      },
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  if (!existing) {
+    throw new Response("Provider connection not found.", { status: 404 });
+  }
+
+  await db.providerConnection.delete({
+    where: {
+      shopId_provider: {
+        shopId: input.shopId,
+        provider: input.provider,
+      },
+    },
+  });
+
+  await db.auditLog.create({
+    data: {
+      shopId: input.shopId,
+      entity: "ProviderConnection",
+      entityId: existing.id,
+      action: "PROVIDER_CONNECTION_DISCONNECTED",
+      actor: "merchant",
+      payload: {
+        provider: input.provider,
+      },
+    },
+  });
+}

--- a/app/services/providerCredentials.server.test.ts
+++ b/app/services/providerCredentials.server.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { decryptProviderCredential, encryptProviderCredential } from "./providerCredentials.server";
+
+describe("providerCredentials.server", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("round-trips encrypted provider credentials", () => {
+    vi.stubEnv("PROVIDER_CREDENTIALS_SECRET", "provider-test-secret");
+
+    const encrypted = encryptProviderCredential("pk_live_fixture_printify_key");
+
+    expect(encrypted).not.toContain("pk_live_fixture_printify_key");
+    expect(decryptProviderCredential(encrypted)).toBe("pk_live_fixture_printify_key");
+  });
+
+  it("uses randomized IVs for repeated encryption", () => {
+    vi.stubEnv("PROVIDER_CREDENTIALS_SECRET", "provider-test-secret");
+
+    const first = encryptProviderCredential("same-value");
+    const second = encryptProviderCredential("same-value");
+
+    expect(first).not.toBe(second);
+  });
+});

--- a/app/services/providerCredentials.server.ts
+++ b/app/services/providerCredentials.server.ts
@@ -1,0 +1,45 @@
+import crypto from "node:crypto";
+
+function getProviderCredentialsSecret() {
+  return (
+    process.env.PROVIDER_CREDENTIALS_SECRET ||
+    (process.env.NODE_ENV === "production" ? undefined : "dev-only-provider-credentials-secret")
+  );
+}
+
+function getKey() {
+  const secret = getProviderCredentialsSecret();
+  if (!secret) {
+    throw new Error("PROVIDER_CREDENTIALS_SECRET is required to store provider credentials.");
+  }
+
+  return crypto.createHash("sha256").update(secret).digest();
+}
+
+export function encryptProviderCredential(plaintext: string) {
+  const key = getKey();
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  return [iv.toString("base64"), tag.toString("base64"), ciphertext.toString("base64")].join(".");
+}
+
+export function decryptProviderCredential(payload: string) {
+  const key = getKey();
+  const [ivPart, tagPart, ciphertextPart] = payload.split(".");
+  if (!ivPart || !tagPart || !ciphertextPart) {
+    throw new Error("Invalid provider credential payload.");
+  }
+
+  const decipher = crypto.createDecipheriv("aes-256-gcm", key, Buffer.from(ivPart, "base64"));
+  decipher.setAuthTag(Buffer.from(tagPart, "base64"));
+
+  const plaintext = Buffer.concat([
+    decipher.update(Buffer.from(ciphertextPart, "base64")),
+    decipher.final(),
+  ]);
+
+  return plaintext.toString("utf8");
+}

--- a/app/services/widgetData.server.ts
+++ b/app/services/widgetData.server.ts
@@ -98,6 +98,26 @@ export type WidgetVariantPayload = {
     estimatedRate: string;
     estimatedAmount: string;
   };
+  reconciliation: {
+    estimatedTotal: string;
+    allocatedDonations: string;
+    retainedByShop: string;
+    labor: string;
+    materials: string;
+    equipment: string;
+    packaging: string;
+    pod: string;
+    mistakeBuffer: string;
+    shopifyFees: string;
+    taxReserve: string;
+    remainder: string;
+  };
+};
+
+type WidgetLineContext = {
+  variantShopifyId: string;
+  quantity: number;
+  lineSubtotal: Prisma.Decimal | null;
 };
 
 export type WidgetProductPayload = {
@@ -218,6 +238,7 @@ export async function buildWidgetProductPayload(
   shopId: string,
   productShopifyId: string,
   db = prisma,
+  lineContext?: WidgetLineContext,
 ): Promise<WidgetProductPayload | null> {
   const context = await loadWidgetProductContext(shopId, productShopifyId, db);
 
@@ -235,8 +256,12 @@ export async function buildWidgetProductPayload(
   const widgetTaxSuppressed = context.taxOffsetCache?.widgetTaxSuppressed ?? true;
   const currencyCode = context.shop.currency;
 
+  const productVariants = lineContext
+    ? context.product.variants.filter((variant) => variant.shopifyId === lineContext.variantShopifyId)
+    : context.product.variants;
+
   const variants = await Promise.all(
-    context.product.variants.map(async (variant) => {
+    productVariants.map(async (variant) => {
       const costs = await resolveCosts(
         shopId,
         variant.id,
@@ -245,8 +270,25 @@ export async function buildWidgetProductPayload(
         db as Parameters<typeof resolveCosts>[4],
       );
       const processingRate = context.shop.paymentRate ?? ZERO;
-      const processingFee = variant.price.mul(processingRate).add(PROCESSING_FLAT_FEE);
-      const preTaxContribution = nonNegative(variant.price.sub(costs.totalCost).sub(processingFee));
+      const quantity = new Prisma.Decimal(lineContext?.quantity ?? 1);
+      const estimatedTotal = lineContext?.lineSubtotal ?? variant.price.mul(quantity);
+      const laborCost = costs.laborCost.mul(quantity);
+      const materialCost = costs.materialCost.mul(quantity);
+      const equipmentCost = costs.equipmentCost.mul(quantity);
+      const packagingCost = costs.packagingCost;
+      const podCost = costs.podCost.mul(quantity);
+      const mistakeBufferAmount = costs.mistakeBufferAmount.mul(quantity);
+      const processingFee = estimatedTotal.mul(processingRate).add(PROCESSING_FLAT_FEE);
+      const preTaxContribution = nonNegative(
+        estimatedTotal
+          .sub(laborCost)
+          .sub(materialCost)
+          .sub(equipmentCost)
+          .sub(packagingCost)
+          .sub(podCost)
+          .sub(mistakeBufferAmount)
+          .sub(processingFee),
+      );
 
       const allocations = context.causeAssignments.map((assignment) => ({
         is501c3: assignment.cause.is501c3,
@@ -266,12 +308,29 @@ export async function buildWidgetProductPayload(
             taxDeductionMode: normalizedTaxDeductionMode,
           });
       const donationPool = nonNegative(preTaxContribution.sub(taxReserve.estimatedTaxReserve));
+      const assignedDonationTotal = context.causeAssignments.reduce(
+        (sum, assignment) => sum.add(donationPool.mul(assignment.percentage).div(100)),
+        ZERO,
+      );
+      const retainedByShop = nonNegative(donationPool.sub(assignedDonationTotal));
+      const attributedTotal = assignedDonationTotal
+        .add(retainedByShop)
+        .add(laborCost)
+        .add(materialCost)
+        .add(equipmentCost)
+        .add(packagingCost)
+        .add(podCost)
+        .add(mistakeBufferAmount)
+        .add(processingFee)
+        .add(taxReserve.estimatedTaxReserve);
+      const rawRemainder = estimatedTotal.sub(attributedTotal);
+      const remainder = rawRemainder.abs().lessThan(new Prisma.Decimal("0.005")) ? ZERO : rawRemainder;
 
       return {
         variantId: variant.shopifyId,
-        price: formatMoney(variant.price),
+        price: formatMoney(estimatedTotal),
         currencyCode,
-        laborCost: formatMoney(costs.laborCost),
+        laborCost: formatMoney(laborCost),
         materialLines: costs.materialLines
           .filter((line) => line.type === "production")
           .map((line) => ({
@@ -289,8 +348,8 @@ export async function buildWidgetProductPayload(
             name: line.name,
             lineCost: formatMoney(line.lineCost),
           })),
-        podCostTotal: formatMoney(costs.podCost),
-        mistakeBufferAmount: formatMoney(costs.mistakeBufferAmount),
+        podCostTotal: formatMoney(podCost),
+        mistakeBufferAmount: formatMoney(mistakeBufferAmount),
         shopifyFees: {
           processingRate: formatPercent(context.shop.paymentRate),
           processingFlatFee: formatMoney(PROCESSING_FLAT_FEE),
@@ -310,6 +369,20 @@ export async function buildWidgetProductPayload(
           suppressed: widgetTaxSuppressed,
           estimatedRate: formatPercent(context.shop.effectiveTaxRate),
           estimatedAmount: widgetTaxSuppressed ? "0.00" : formatMoney(taxReserve.estimatedTaxReserve),
+        },
+        reconciliation: {
+          estimatedTotal: formatMoney(estimatedTotal),
+          allocatedDonations: formatMoney(assignedDonationTotal),
+          retainedByShop: formatMoney(retainedByShop),
+          labor: formatMoney(laborCost),
+          materials: formatMoney(materialCost),
+          equipment: formatMoney(equipmentCost),
+          packaging: formatMoney(packagingCost),
+          pod: formatMoney(podCost),
+          mistakeBuffer: formatMoney(mistakeBufferAmount),
+          shopifyFees: formatMoney(processingFee),
+          taxReserve: widgetTaxSuppressed ? "0.00" : formatMoney(taxReserve.estimatedTaxReserve),
+          remainder: formatMoney(remainder),
         },
       };
     }),

--- a/docs/current-implementation-status.md
+++ b/docs/current-implementation-status.md
@@ -64,7 +64,8 @@ This file is intentionally lightweight and operational. It should summarize real
 
 ### Deferred or intentionally incomplete
 
-- [ ] POD/provider connections
+- [~] POD/provider connections
+  Provider Connections now has a real admin foundation page plus stored Printify credential state, but provider sync, mapping, and POD cost resolution are still pending.
 - [ ] Full inline bulk editor
 - [ ] Full design revisit for large-list filtering UX
 

--- a/extensions/count-on-us-product-widget/assets/cart-donation-summary.js
+++ b/extensions/count-on-us-product-widget/assets/cart-donation-summary.js
@@ -1,9 +1,13 @@
 (function () {
   window.__COUNT_ON_US_CART_SUMMARY_READY__ = false;
+
   const money = (value) => {
     const parsed = Number.parseFloat(String(value ?? "0"));
     return Number.isFinite(parsed) ? parsed : 0;
   };
+
+  const roundCurrency = (value) => Math.round((money(value) + Number.EPSILON) * 100) / 100;
+
   const formatMoney = (value, currencyCode) =>
     new Intl.NumberFormat(undefined, {
       style: "currency",
@@ -11,6 +15,7 @@
       minimumFractionDigits: 2,
       maximumFractionDigits: 2,
     }).format(value);
+
   const escapeHtml = (value) =>
     String(value ?? "")
       .replace(/&/g, "&amp;")
@@ -18,6 +23,7 @@
       .replace(/>/g, "&gt;")
       .replace(/"/g, "&quot;")
       .replace(/'/g, "&#39;");
+
   const safeExternalUrl = (value) => {
     if (!value) return "";
     try {
@@ -27,48 +33,307 @@
       return "";
     }
   };
-  const findVariant = (payload, variantId) => payload.variants.find((variant) => variant.variantId === variantId) || payload.variants[0] || null;
-  const scaleVariant = (variant, quantity) => ({
-    ...variant,
-    causes: variant.causes.map((cause) => ({
-      ...cause,
-      estimatedDonationAmount: (money(cause.estimatedDonationAmount) * Math.max(1, quantity)).toFixed(2),
-    })),
-  });
+
+  const slugify = (value) =>
+    String(value ?? "")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+
+  const RECONCILIATION_EXPLANATIONS = {
+    estimatedTotal:
+      "This is the current estimated total for the items in your cart before Count On Us subtracts the costs and reserves that need to be covered first.",
+    labor:
+      "This portion helps cover the time required to make, prepare, or fulfill these items before any donation amount is estimated.",
+    materials:
+      "This portion helps cover the raw materials used to make the items in your cart before any donation amount is estimated.",
+    equipment:
+      "This portion helps cover equipment usage and wear involved in producing the items in your cart before any donation amount is estimated.",
+    packaging:
+      "This estimate helps cover packaging and shipping materials, which need to be paid before the remaining amount can be donated.",
+    pod: "This portion helps cover any print-on-demand production cost tied to the items in your cart before any donation amount is estimated.",
+    mistakeBuffer:
+      "This portion sets aside a small buffer for remakes, spoilage, or similar production issues so those costs do not come out of the donation estimate later.",
+    fees:
+      "This estimate helps cover payment processing fees charged on the order. The exact amount can vary depending on how the purchase is completed.",
+    taxReserve:
+      "This estimate sets aside money for taxes that may be owed on the sale, so that amount is not counted as part of the donation estimate.",
+    estimatedDonationPool:
+      "This is the amount left after estimated costs, fees, and reserves are subtracted from the total. That remainder is then split between the causes and any portion the shop keeps.",
+    allocatedDonations:
+      "This is the portion of the remaining amount that is currently assigned to the causes connected to these items.",
+    retainedByShop:
+      "This is any remaining portion that stays with the shop instead of being assigned to a cause. When the items are set to donate 100%, this should be zero.",
+    remainder:
+      "This shows any small leftover difference between the total and the displayed estimate buckets. It should usually be zero.",
+  };
+
+  const renderInfoLabel = (label, explanationKey) => {
+    const explanation = RECONCILIATION_EXPLANATIONS[explanationKey];
+    if (!explanation) return escapeHtml(label);
+
+    const tooltipId = `count-on-us-tooltip-${slugify(explanationKey)}-${slugify(label)}`;
+    return `<span class="count-on-us-widget__label-with-info"><span>${escapeHtml(label)}</span><span class="count-on-us-widget__tooltip"><button type="button" class="count-on-us-widget__tooltip-trigger" aria-describedby="${tooltipId}" aria-label="Learn more about ${escapeHtml(label)}">?</button><span class="count-on-us-widget__tooltip-bubble" id="${tooltipId}" role="tooltip">${escapeHtml(explanation)}</span></span></span>`;
+  };
+
   const fetchJson = async (url) => {
     const response = await fetch(url, { credentials: "same-origin", headers: { Accept: "application/json" } });
     if (!response.ok) throw new Error(`Widget request failed with ${response.status}`);
     return response.json();
   };
-  const aggregateCartCauseTotals = (lines, payloads) => {
-    const payloadMap = new Map(payloads.map((payload) => [payload.productId, payload]));
-    const totals = new Map();
-    let hasDonationProducts = false;
-    lines.forEach((line) => {
-      const payload = payloadMap.get(line.productId);
-      if (!payload || !payload.visible) return;
-      const variant = findVariant(payload, line.variantId);
-      if (!variant) return;
-      hasDonationProducts = true;
-      scaleVariant(variant, line.quantity).causes.forEach((cause) => {
-        const current = totals.get(cause.causeId) || {
-          causeId: cause.causeId,
-          name: cause.name,
-          amount: 0,
-          donationCurrencyCode: cause.donationCurrencyCode,
-          donationLink: cause.donationLink,
-        };
-        current.amount += money(cause.estimatedDonationAmount);
-        totals.set(cause.causeId, current);
-      });
-    });
-    return {
-      hasDonationProducts,
-      totals: Array.from(totals.values())
-        .map((cause) => ({ ...cause, amount: cause.amount.toFixed(2) }))
-        .sort((left, right) => money(right.amount) - money(left.amount) || left.name.localeCompare(right.name)),
-    };
+
+  const toProductGid = (value) => {
+    const normalized = String(value ?? "").trim();
+    if (!normalized) return "";
+    return normalized.startsWith("gid://shopify/Product/") ? normalized : `gid://shopify/Product/${normalized}`;
   };
+
+  const toVariantGid = (value) => {
+    const normalized = String(value ?? "").trim();
+    if (!normalized) return "";
+    return normalized.startsWith("gid://shopify/ProductVariant/")
+      ? normalized
+      : `gid://shopify/ProductVariant/${normalized}`;
+  };
+
+  const CART_LINE_CONTAINER_SELECTORS = [
+    ".cart-item",
+    '[class*="cart-item"]',
+    ".cart__item",
+    '[class*="cart__item"]',
+    ".cart-drawer__item",
+    ".drawer__item",
+    '[class*="line-item"]',
+    "[data-cart-item]",
+    "[data-cart-line]",
+    "tr",
+    "li",
+  ];
+  const CART_LINE_DETAILS_SELECTORS = [
+    ".cart-item__details",
+    ".cart-item__content",
+    ".cart-item__info",
+    ".cart__item-details",
+    ".cart__item-info",
+    ".line-item__details",
+    ".line-item__content",
+    ".line-item__info",
+    '[class*="details"]',
+    '[class*="content"]',
+    '[class*="info"]',
+    '[class*="description"]',
+    "td:nth-child(2)",
+  ];
+  const CART_LINE_TITLE_SELECTORS = [
+    ".cart-item__name",
+    ".cart-item__title",
+    ".cart__item-title",
+    ".line-item__title",
+    '[class*="product-title"]',
+    '[class*="item-title"]',
+    '[class*="cart-item__name"]',
+    '[class*="cart-item__title"]',
+    '[class*="cart__item-title"]',
+    '[class*="line-item__title"]',
+    "a[href*=\"/products/\"]",
+    "h1, h2, h3, h4, h5, h6",
+  ];
+
+  const setContainerVisibility = (container, visible) => {
+    if (container.dataset.countOnUsDesignMode === "true") {
+      container.hidden = false;
+      container.removeAttribute("hidden");
+      container.style.removeProperty("display");
+      return;
+    }
+
+    if (visible) {
+      container.hidden = false;
+      container.removeAttribute("hidden");
+      container.style.removeProperty("display");
+      return;
+    }
+
+    container.hidden = true;
+    container.setAttribute("hidden", "");
+    container.style.display = "none";
+  };
+
+  const buildCauseSupportLabel = (variant) => {
+    if (!variant || !Array.isArray(variant.causes) || !variant.causes.length) return "";
+    return variant.causes
+      .map((cause) => `${money(cause.donationPercentage).toFixed(0)}% to ${cause.name}`)
+      .join("\n");
+  };
+
+  const buildCompactCauseSupportLabel = (variant) => {
+    if (!variant || !Array.isArray(variant.causes) || !variant.causes.length) return "";
+    return "Donations apply";
+  };
+
+  const getCartSearchRoot = (container) => {
+    if (container instanceof HTMLElement) {
+      const formRoot = container.closest('form[action*="/cart"]');
+      if (formRoot instanceof HTMLElement) return formRoot;
+    }
+
+    const documentRoot = document.querySelector('form[action*="/cart"]');
+    if (documentRoot instanceof HTMLElement) return documentRoot;
+    return document;
+  };
+
+  const hasCartLineSignals = (container) => {
+    if (!(container instanceof HTMLElement)) return false;
+
+    const hasProductIdentity = Boolean(
+      container.querySelector(
+        [
+          'a[href*="/products/"]',
+          ".cart-item__name",
+          ".cart-item__title",
+          ".cart__item-title",
+          ".line-item__title",
+          '[class*="product-title"]',
+          '[class*="item-title"]',
+        ].join(", "),
+      ),
+    );
+    const hasCartControls = Boolean(
+      container.querySelector(
+        [
+          'input[name="updates[]"]',
+          'input[name^="updates"]',
+          'select[name="updates[]"]',
+          'select[name^="updates"]',
+          'button[name="plus"]',
+          'button[name="minus"]',
+          '[data-quantity-button]',
+          '[data-qty-button]',
+          'button[aria-label*="remove" i]',
+          '[data-cart-remove]',
+          'a[href*="/cart/change"]',
+          "cart-remove-button",
+          "quantity-popover",
+        ].join(", "),
+      ),
+    );
+
+    return hasProductIdentity && hasCartControls;
+  };
+
+  const findCartLineContainers = (container) => {
+    const searchRoot = getCartSearchRoot(container);
+    const quantityControls = Array.from(
+      searchRoot.querySelectorAll(
+        [
+          'input[name="updates[]"]',
+          'input[name^="updates"]',
+          'select[name="updates[]"]',
+          'select[name^="updates"]',
+          'button[name="plus"]',
+          'button[name="minus"]',
+          '[data-quantity-button]',
+          '[data-qty-button]',
+          'button[aria-label*="remove" i]',
+          '[data-cart-remove]',
+          'a[href*="/cart/change"]',
+          "cart-remove-button",
+          "quantity-popover",
+        ].join(", "),
+      ),
+    );
+    const matched = quantityControls
+      .map((control) => {
+        if (!(control instanceof HTMLElement)) return null;
+        return control.closest(CART_LINE_CONTAINER_SELECTORS.join(", "));
+      })
+      .filter(
+        (lineContainer, index, array) =>
+          lineContainer instanceof HTMLElement &&
+          hasCartLineSignals(lineContainer) &&
+          array.indexOf(lineContainer) === index,
+      );
+
+    if (matched.length) return matched;
+
+    return Array.from(searchRoot.querySelectorAll(CART_LINE_CONTAINER_SELECTORS.join(", ")))
+      .filter((lineContainer) => lineContainer instanceof HTMLElement)
+      .filter((lineContainer) => hasCartLineSignals(lineContainer))
+      .filter((lineContainer, index, array) => array.indexOf(lineContainer) === index);
+  };
+
+  const findAnnotationTarget = (container) => {
+    if (!(container instanceof HTMLElement)) return null;
+    const title = container.querySelector(CART_LINE_TITLE_SELECTORS.join(", "));
+    if (title instanceof HTMLElement) {
+      return title;
+    }
+
+    const preferred = container.querySelector(CART_LINE_DETAILS_SELECTORS.join(", "));
+    if (preferred instanceof HTMLElement) return preferred;
+
+    const textBlocks = Array.from(container.querySelectorAll("p, div, dd, td, span"))
+      .filter((node) => node instanceof HTMLElement)
+      .filter((node) => node.textContent && node.textContent.trim().length > 0);
+    return textBlocks[0] || container;
+  };
+
+  let ignoreAnnotationMutationsUntil = 0;
+
+  const annotateCartLines = (entries, container) => {
+    const containers = findCartLineContainers(container);
+    if (!containers.length) return;
+
+    ignoreAnnotationMutationsUntil = Date.now() + 250;
+    containers.forEach((cartLineContainer) => {
+      if (!(cartLineContainer instanceof HTMLElement)) return;
+      cartLineContainer.querySelectorAll("[data-count-on-us-cart-annotation]").forEach((annotation) => annotation.remove());
+    });
+
+    entries.forEach(({ payload }, index) => {
+      const cartLineContainer = containers[index];
+      if (!(cartLineContainer instanceof HTMLElement) || !payload) return;
+      const variant = payload.variants[0] || null;
+      if (!variant || !variant.causes.length) return;
+
+      const supportLabel = buildCauseSupportLabel(variant);
+      if (!supportLabel) return;
+      const target = findAnnotationTarget(cartLineContainer);
+      if (!(target instanceof HTMLElement)) return;
+
+      const annotation = document.createElement("p");
+      annotation.className = "count-on-us-widget__cart-annotation";
+      annotation.dataset.countOnUsCartAnnotation = "true";
+      const compactLabel = buildCompactCauseSupportLabel(variant);
+      const tooltipId = `count-on-us-cart-annotation-${index}`;
+      annotation.innerHTML = `<span class="count-on-us-widget__tooltip count-on-us-widget__cart-annotation-tooltip"><button type="button" class="count-on-us-widget__cart-annotation-trigger" aria-describedby="${tooltipId}" aria-label="Show supported causes">${escapeHtml(compactLabel)}</button><span class="count-on-us-widget__tooltip-bubble" id="${tooltipId}" role="tooltip">${escapeHtml(supportLabel)}</span></span>`;
+
+      if (target.matches(CART_LINE_TITLE_SELECTORS.join(", "))) {
+        target.insertAdjacentElement("afterend", annotation);
+      } else {
+        target.appendChild(annotation);
+      }
+    });
+    ignoreAnnotationMutationsUntil = Date.now() + 250;
+  };
+
+  const mutationIsCartRelevant = (mutations) =>
+    mutations.some((mutation) => {
+      if (Date.now() < ignoreAnnotationMutationsUntil) return false;
+      if (!(mutation.target instanceof Element)) return false;
+      if (
+        mutation.target.closest("[data-count-on-us-cart-summary]") ||
+        mutation.target.closest("[data-count-on-us-cart-annotation]") ||
+        mutation.target.closest(".count-on-us-widget__tooltip-bubble")
+      ) {
+        return false;
+      }
+
+      return isCartRelevantTarget(mutation.target) ||
+        Array.from(mutation.addedNodes).some((node) => node instanceof Element && isCartRelevantTarget(node)) ||
+        Array.from(mutation.removedNodes).some((node) => node instanceof Element && isCartRelevantTarget(node));
+    });
+
   const trapFocus = (dialog, event) => {
     if (event.key !== "Tab") return;
     const focusables = dialog.querySelectorAll("button, [href], input, select, textarea, [tabindex]:not([tabindex='-1'])");
@@ -83,6 +348,7 @@
       first.focus();
     }
   };
+
   const parseCartSummaryLines = (container) => {
     const linesScript = container.querySelector("[data-count-on-us-cart-lines]");
     const encodedLines = container.dataset.countOnUsCartLinesJson || "";
@@ -94,9 +360,59 @@
       return [];
     }
   };
+
+  const loadCurrentCartLines = async (container) => {
+    try {
+      const cart = await fetchJson("/cart.js");
+      if (!cart || !Array.isArray(cart.items)) {
+        return parseCartSummaryLines(container);
+      }
+
+      return cart.items
+        .map((item) => ({
+          productId: toProductGid(item.product_id),
+          variantId: toVariantGid(item.variant_id),
+          quantity: Math.max(1, Number.parseInt(String(item.quantity || "1"), 10) || 1),
+          lineSubtotal:
+            typeof item.final_line_price === "number"
+              ? roundCurrency(item.final_line_price / 100)
+              : typeof item.line_price === "number"
+                ? roundCurrency(item.line_price / 100)
+                : undefined,
+        }))
+        .filter((line) => line.productId && line.variantId);
+    } catch (error) {
+      console.error("[Count On Us Cart Summary] Failed to read /cart.js, falling back to embedded lines:", error);
+      return parseCartSummaryLines(container);
+    }
+  };
+
+  const loadEntriesForLines = async (container, lines) => {
+    const proxyBase = container.dataset.proxyBase || "/apps/count-on-us";
+    return Promise.all(
+      lines.map(async (line) => {
+        const productId = String(line.productId || "");
+        if (!productId) {
+          return { line, payload: null };
+        }
+
+        const params = new URLSearchParams({
+          variantId: String(line.variantId || ""),
+          quantity: String(Math.max(1, Number.parseInt(String(line.quantity || "1"), 10) || 1)),
+        });
+        if (line.lineSubtotal != null && line.lineSubtotal !== "") {
+          params.set("lineSubtotal", String(line.lineSubtotal));
+        }
+        const payload = (await fetchJson(`${proxyBase}/products/${encodeURIComponent(productId)}?${params.toString()}`)).data;
+        return { line, payload };
+      }),
+    );
+  };
+
   function createController(trigger) {
     let modal = null;
     let lastFocusedElement = null;
+
     const closeModal = () => {
       if (!modal) return;
       modal.remove();
@@ -105,12 +421,13 @@
       if (lastFocusedElement && typeof lastFocusedElement.focus === "function") lastFocusedElement.focus();
       else trigger.focus();
     };
+
     const openModal = (content) => {
       if (modal) closeModal();
       lastFocusedElement = document.activeElement;
       modal = document.createElement("div");
       modal.className = "count-on-us-widget__modal-overlay";
-      modal.innerHTML = `<div class="count-on-us-widget__modal" role="dialog" aria-modal="true" aria-labelledby="count-on-us-cart-title"><div class="count-on-us-widget__modal-header"><div><h3 id="count-on-us-cart-title" class="count-on-us-widget__heading">Cart donation impact</h3><p class="count-on-us-widget__description">Estimated donation totals across the causes in this cart.</p></div><button type="button" class="count-on-us-widget__modal-close" data-count-on-us-cart-close aria-label="Close donation summary">&times;</button></div><div>${content}</div></div>`;
+      modal.innerHTML = `<div class="count-on-us-widget__modal" role="dialog" aria-modal="true" aria-labelledby="count-on-us-cart-title"><div class="count-on-us-widget__modal-header"><div><h3 id="count-on-us-cart-title" class="count-on-us-widget__heading">Cart donation impact</h3><p class="count-on-us-widget__description">Estimated donation totals across the causes in this cart.</p></div><button type="button" class="count-on-us-widget__modal-close" data-count-on-us-cart-close aria-label="Close donation summary">&times;</button></div><div class="count-on-us-widget__modal-body">${content}</div></div>`;
       modal.addEventListener("click", (event) => {
         if (event.target === modal) closeModal();
       });
@@ -129,9 +446,57 @@
       closeButton.addEventListener("click", closeModal);
       closeButton.focus();
     };
+
     return { openModal };
   }
+
   const controllers = new WeakMap();
+  const refreshState = new WeakMap();
+  const buildCartSignature = (lines) =>
+    lines
+      .map((line) =>
+        [line.productId || "", line.variantId || "", Math.max(1, Number.parseInt(String(line.quantity || "1"), 10) || 1), roundCurrency(line.lineSubtotal || 0)].join(":"),
+      )
+      .join("|");
+
+  const getCachedEntriesForLines = (container, lines) => {
+    const state = refreshState.get(container) || {};
+    const signature = buildCartSignature(lines);
+    if (state.lastSignature === signature && Array.isArray(state.lastEntries)) {
+      return { signature, entries: state.lastEntries, hasCachedEntries: true };
+    }
+
+    return { signature, entries: null, hasCachedEntries: false };
+  };
+
+  const isCartRelevantTarget = (target) => {
+    if (!(target instanceof Element)) return false;
+
+    return Boolean(
+      target.closest(
+        [
+          '[name="updates[]"]',
+          '[name^="updates"]',
+          "[data-cart-item]",
+          "[data-cart-line]",
+          ".cart-item",
+          '[class*="cart-item"]',
+          ".cart__item",
+          '[class*="cart__item"]',
+          ".cart-drawer__item",
+          ".drawer__item",
+          'form[action*="/cart"]',
+          'button[name="add"]',
+          '[name="plus"]',
+          '[name="minus"]',
+          '[data-quantity-button]',
+          '[data-qty-button]',
+          '[href*="/cart"]',
+        ].join(", "),
+      ),
+    );
+  };
+
   const getController = (trigger) => {
     let controller = controllers.get(trigger);
     if (!controller) {
@@ -140,36 +505,244 @@
     }
     return controller;
   };
+
+  const refreshContainer = async (container) => {
+    const currentState = refreshState.get(container) || {};
+    if (currentState.inFlight) {
+      refreshState.set(container, { ...currentState, pending: true });
+      return;
+    }
+
+    refreshState.set(container, { ...currentState, inFlight: true, pending: false });
+    try {
+      const lines = await loadCurrentCartLines(container);
+      if (!lines.length) {
+        annotateCartLines([], container);
+        setContainerVisibility(container, false);
+        refreshState.set(container, {
+          ...refreshState.get(container),
+          lastSignature: "",
+          lastEntries: [],
+          lastHasDonationProducts: false,
+        });
+        return;
+      }
+
+      const { signature, entries: cachedEntries, hasCachedEntries } = getCachedEntriesForLines(container, lines);
+      const entries = hasCachedEntries ? cachedEntries : await loadEntriesForLines(container, lines);
+      const hasDonationProducts = entries.some(({ payload }) => {
+        const variant = payload?.variants?.[0];
+        return Boolean(payload?.visible || (variant && variant.causes && variant.causes.length > 0));
+      });
+
+      refreshState.set(container, {
+        ...refreshState.get(container),
+        lastSignature: signature,
+        lastEntries: entries,
+        lastHasDonationProducts: hasDonationProducts,
+      });
+      annotateCartLines(entries, container);
+      setContainerVisibility(container, hasDonationProducts);
+    } catch (error) {
+      console.error("[Count On Us Cart Summary] Failed to refresh widget state:", error);
+      setContainerVisibility(container, true);
+    } finally {
+      const nextState = refreshState.get(container) || {};
+      if (nextState.pending) {
+        refreshState.set(container, { ...nextState, inFlight: false, pending: false });
+        window.setTimeout(() => {
+          void refreshContainer(container);
+        }, 120);
+      } else {
+        refreshState.set(container, { ...nextState, inFlight: false, pending: false });
+      }
+    }
+  };
+
+  const scheduleRefresh = (container, delay = 180) => {
+    const state = refreshState.get(container) || {};
+    if (state.timer) {
+      window.clearTimeout(state.timer);
+    }
+    const timer = window.setTimeout(() => {
+      const latest = refreshState.get(container) || {};
+      refreshState.set(container, { ...latest, timer: null });
+      void refreshContainer(container);
+    }, delay);
+    refreshState.set(container, { ...state, timer });
+  };
+
+  const aggregateCartCauseTotals = (entries) => {
+    const totals = new Map();
+    const costBreakdown = {
+      estimatedTotal: 0,
+      allocatedDonations: 0,
+      retainedByShop: 0,
+      labor: 0,
+      materials: 0,
+      equipment: 0,
+      packaging: 0,
+      pod: 0,
+      mistakeBuffer: 0,
+      fees: 0,
+      taxReserve: 0,
+    };
+    let hasDonationProducts = false;
+
+    entries.forEach(({ payload }) => {
+      if (!payload) return;
+      const variant = payload.variants[0] || null;
+      if (!variant) return;
+      if (variant.causes.length > 0) {
+        hasDonationProducts = true;
+      }
+
+      costBreakdown.estimatedTotal = roundCurrency(costBreakdown.estimatedTotal + money(variant.reconciliation?.estimatedTotal));
+      costBreakdown.allocatedDonations = roundCurrency(
+        costBreakdown.allocatedDonations + money(variant.reconciliation?.allocatedDonations),
+      );
+      costBreakdown.retainedByShop = roundCurrency(
+        costBreakdown.retainedByShop + money(variant.reconciliation?.retainedByShop),
+      );
+      costBreakdown.labor = roundCurrency(costBreakdown.labor + money(variant.reconciliation?.labor));
+      costBreakdown.materials = roundCurrency(costBreakdown.materials + money(variant.reconciliation?.materials));
+      costBreakdown.equipment = roundCurrency(costBreakdown.equipment + money(variant.reconciliation?.equipment));
+      costBreakdown.packaging = roundCurrency(costBreakdown.packaging + money(variant.reconciliation?.packaging));
+      costBreakdown.pod = roundCurrency(costBreakdown.pod + money(variant.reconciliation?.pod));
+      costBreakdown.mistakeBuffer = roundCurrency(
+        costBreakdown.mistakeBuffer + money(variant.reconciliation?.mistakeBuffer),
+      );
+      costBreakdown.fees = roundCurrency(costBreakdown.fees + money(variant.reconciliation?.shopifyFees));
+      costBreakdown.taxReserve = roundCurrency(costBreakdown.taxReserve + money(variant.reconciliation?.taxReserve));
+
+      variant.causes.forEach((cause) => {
+        const current = totals.get(cause.causeId) || {
+          causeId: cause.causeId,
+          name: cause.name,
+          amount: 0,
+          donationCurrencyCode: cause.donationCurrencyCode,
+          donationLink: cause.donationLink,
+        };
+        current.amount += money(cause.estimatedDonationAmount);
+        totals.set(cause.causeId, current);
+      });
+    });
+
+    const attributedTotal = roundCurrency(
+      costBreakdown.allocatedDonations +
+        costBreakdown.retainedByShop +
+        costBreakdown.labor +
+        costBreakdown.materials +
+        costBreakdown.equipment +
+        costBreakdown.packaging +
+        costBreakdown.pod +
+        costBreakdown.mistakeBuffer +
+        costBreakdown.fees +
+        costBreakdown.taxReserve,
+    );
+
+    const remainder = roundCurrency(costBreakdown.estimatedTotal - attributedTotal);
+
+    return {
+      hasDonationProducts,
+      totals: Array.from(totals.values())
+        .map((cause) => ({ ...cause, amount: cause.amount.toFixed(2) }))
+        .sort((left, right) => money(right.amount) - money(left.amount) || left.name.localeCompare(right.name)),
+      costBreakdown: {
+        ...Object.fromEntries(Object.entries(costBreakdown).map(([key, value]) => [key, value.toFixed(2)])),
+        attributedTotal: attributedTotal.toFixed(2),
+        remainder: remainder.toFixed(2),
+      },
+    };
+  };
+
+  const buildReconciliationRows = (costBreakdown) =>
+    [
+      { label: "Labor", key: "labor", value: money(costBreakdown.labor), estimated: false },
+      { label: "Materials", key: "materials", value: money(costBreakdown.materials), estimated: false },
+      { label: "Equipment", key: "equipment", value: money(costBreakdown.equipment), estimated: false },
+      { label: "Packaging", key: "packaging", value: money(costBreakdown.packaging), estimated: true },
+      { label: "POD", key: "pod", value: money(costBreakdown.pod), estimated: false },
+      { label: "Mistake buffer", key: "mistakeBuffer", value: money(costBreakdown.mistakeBuffer), estimated: false },
+      { label: "Shopify fees", key: "fees", value: money(costBreakdown.fees), estimated: true },
+      { label: "Tax reserve", key: "taxReserve", value: money(costBreakdown.taxReserve), estimated: true },
+    ]
+      .filter((row) => Math.abs(row.value) >= 0.01)
+      .sort((left, right) => right.value - left.value || left.label.localeCompare(right.label));
+
   async function handleTrigger(container, trigger) {
     const { openModal } = getController(trigger);
-    const lines = parseCartSummaryLines(container);
+    const lines = await loadCurrentCartLines(container);
     if (!lines.length) {
       openModal('<p class="count-on-us-widget__status">No donation products in this cart yet.</p>');
       return;
     }
+
     openModal('<p class="count-on-us-widget__status">Loading donation summary...</p>');
+
     try {
-      const proxyBase = container.dataset.proxyBase || "/apps/count-on-us";
-      const uniqueProducts = Array.from(new Set(lines.map((line) => line.productId)));
-      const payloads = await Promise.all(
-        uniqueProducts.map(async (productId) => (await fetchJson(`${proxyBase}/products/${encodeURIComponent(productId)}`)).data),
-      );
-      const summary = aggregateCartCauseTotals(lines, payloads);
+      const { signature, entries: cachedEntries, hasCachedEntries } = getCachedEntriesForLines(container, lines);
+      const entries = hasCachedEntries ? cachedEntries : await loadEntriesForLines(container, lines);
+      if (!hasCachedEntries) {
+        const state = refreshState.get(container) || {};
+        refreshState.set(container, { ...state, lastSignature: signature, lastEntries: entries });
+      }
+
+      const summary = aggregateCartCauseTotals(entries);
+      annotateCartLines(entries, container);
       if (!summary.hasDonationProducts || !summary.totals.length) {
         openModal('<p class="count-on-us-widget__status">No donation products in this cart yet.</p>');
         return;
       }
-      openModal(`<section class="count-on-us-widget__section"><h4 class="count-on-us-widget__section-title">Causes</h4><div class="count-on-us-widget__list">${summary.totals
-        .map((cause) => {
-          const donationLink = safeExternalUrl(cause.donationLink);
-          return `<article class="count-on-us-widget__cause"><div class="count-on-us-widget__cause-line"><strong>${escapeHtml(cause.name)}</strong><strong>${formatMoney(money(cause.amount), cause.donationCurrencyCode)}</strong></div>${donationLink ? `<div class="count-on-us-widget__cause-line"><span class="count-on-us-widget__subdued">Estimated across your cart</span><a href="${donationLink}" target="_blank" rel="noreferrer" class="count-on-us-widget__subdued">Donate direct</a></div>` : '<div class="count-on-us-widget__cause-line"><span class="count-on-us-widget__subdued">Estimated across your cart</span></div>'}</article>`;
-        })
-        .join("")}</div></section>`);
+
+      const currencyCode = entries[0]?.payload?.variants?.[0]?.currencyCode || "USD";
+      const reconciliationRows = buildReconciliationRows(summary.costBreakdown);
+      const remainderRow =
+        Math.abs(money(summary.costBreakdown.remainder)) >= 0.01
+          ? `<div class="count-on-us-widget__row"><span>${renderInfoLabel("Unattributed remainder", "remainder")}</span><strong>${formatMoney(money(summary.costBreakdown.remainder), currencyCode)}</strong></div>`
+          : "";
+      const waterfallRows = reconciliationRows
+        .map(
+          (row) =>
+            `<div class="count-on-us-widget__row"><span>Less: ${renderInfoLabel(row.label, row.key)}${row.estimated ? ' <em class="count-on-us-widget__estimate-tag">(estimate)</em>' : ""}</span><strong>- ${formatMoney(row.value, currencyCode)}</strong></div>`,
+        )
+        .join("");
+
+      openModal(
+        `<section class="count-on-us-widget__section"><h4 class="count-on-us-widget__section-title">Causes</h4><div class="count-on-us-widget__list">${summary.totals
+          .map((cause) => {
+            const donationLink = safeExternalUrl(cause.donationLink);
+            return `<article class="count-on-us-widget__cause"><div class="count-on-us-widget__cause-line">${donationLink ? `<a href="${donationLink}" target="_blank" rel="noreferrer" class="count-on-us-widget__cause-link"><strong>${escapeHtml(cause.name)}</strong><span class="count-on-us-widget__cause-link-text">Learn more</span></a>` : `<strong>${escapeHtml(cause.name)}</strong>`}<strong>${formatMoney(money(cause.amount), cause.donationCurrencyCode)}</strong></div><div class="count-on-us-widget__cause-line"><span class="count-on-us-widget__subdued">Estimated across your cart</span></div></article>`;
+          })
+          .join("")}</div></section><section class="count-on-us-widget__section"><details class="count-on-us-widget__details" data-count-on-us-cart-breakdown><summary class="count-on-us-widget__details-summary">See how this estimate is calculated</summary><div class="count-on-us-widget__details-body"><h4 class="count-on-us-widget__section-title">Estimated reconciliation</h4><div class="count-on-us-widget__list"><div class="count-on-us-widget__row"><span>${renderInfoLabel("Estimated total", "estimatedTotal")}</span><strong>${formatMoney(money(summary.costBreakdown.estimatedTotal), currencyCode)}</strong></div>${waterfallRows}<div class="count-on-us-widget__row count-on-us-widget__row--total"><span>${renderInfoLabel("Equals: amount remaining after costs", "estimatedDonationPool")}</span><strong>${formatMoney(money(summary.costBreakdown.allocatedDonations) + money(summary.costBreakdown.retainedByShop), currencyCode)}</strong></div><div class="count-on-us-widget__row"><span>${renderInfoLabel("Allocated to causes", "allocatedDonations")}</span><strong>${formatMoney(money(summary.costBreakdown.allocatedDonations), currencyCode)}</strong></div><div class="count-on-us-widget__row"><span>${renderInfoLabel("Retained by shop", "retainedByShop")}</span><strong>${formatMoney(money(summary.costBreakdown.retainedByShop), currencyCode)}</strong></div>${remainderRow}</div></div></details></section>`,
+      );
     } catch (error) {
       console.error("[Count On Us Cart Summary] Failed to load summary:", error);
       openModal('<p class="count-on-us-widget__status count-on-us-widget__status--error">Donation summary unavailable right now.</p>');
     }
   }
+
+  async function initializeContainer(container) {
+    if (container.dataset.countOnUsCartInitialized === "true") return;
+    container.dataset.countOnUsCartInitialized = "true";
+
+    await refreshContainer(container);
+
+    const handleDocumentEvent = (event) => {
+      if (!isCartRelevantTarget(event.target)) return;
+      scheduleRefresh(container);
+    };
+    document.addEventListener("change", handleDocumentEvent);
+    document.addEventListener("input", handleDocumentEvent);
+    document.addEventListener("click", handleDocumentEvent);
+
+    const observer = new MutationObserver((mutations) => {
+      if (!mutationIsCartRelevant(mutations)) return;
+      scheduleRefresh(container);
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
+
   document.addEventListener("click", (event) => {
     const trigger = event.target instanceof Element ? event.target.closest("[data-count-on-us-cart-trigger]") : null;
     if (!(trigger instanceof HTMLElement)) return;
@@ -178,5 +751,21 @@
     event.preventDefault();
     void handleTrigger(container, trigger);
   });
-  window.__COUNT_ON_US_CART_SUMMARY_READY__ = true;
+
+  const initializeAllContainers = () =>
+    Promise.all(
+      Array.from(document.querySelectorAll("[data-count-on-us-cart-summary]")).map((element) =>
+        initializeContainer(element),
+      ),
+    ).finally(() => {
+      window.__COUNT_ON_US_CART_SUMMARY_READY__ = true;
+    });
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", () => {
+      void initializeAllContainers();
+    });
+  } else {
+    void initializeAllContainers();
+  }
 })();

--- a/extensions/count-on-us-product-widget/assets/cart-donation-summary.js
+++ b/extensions/count-on-us-product-widget/assets/cart-donation-summary.js
@@ -1,4 +1,5 @@
 (function () {
+  window.__COUNT_ON_US_CART_SUMMARY_READY__ = false;
   const money = (value) => {
     const parsed = Number.parseFloat(String(value ?? "0"));
     return Number.isFinite(parsed) ? parsed : 0;
@@ -177,4 +178,5 @@
     event.preventDefault();
     void handleTrigger(container, trigger);
   });
+  window.__COUNT_ON_US_CART_SUMMARY_READY__ = true;
 })();

--- a/extensions/count-on-us-product-widget/assets/donation-widget.css
+++ b/extensions/count-on-us-product-widget/assets/donation-widget.css
@@ -5,7 +5,13 @@
     radial-gradient(circle at top left, rgba(254, 240, 138, 0.22), transparent 38%),
     linear-gradient(180deg, #ffffff 0%, #faf7ef 100%);
   color: #1f2937;
-  padding: 1rem;
+  padding: 0.9rem 1rem 1rem;
+}
+
+.count-on-us-widget--cart-summary {
+  width: min(100%, 29rem);
+  max-width: 29rem;
+  padding-top: 1.2rem;
 }
 
 .count-on-us-widget[hidden] {
@@ -14,7 +20,7 @@
 
 .count-on-us-widget__header {
   display: grid;
-  gap: 0.5rem;
+  gap: 0.35rem;
 }
 
 .count-on-us-widget__heading {
@@ -27,6 +33,7 @@
   margin: 0;
   color: #4b5563;
   font-size: 0.92rem;
+  line-height: 1.4;
 }
 
 .count-on-us-widget__toggle {
@@ -41,8 +48,14 @@
   color: #ffffff;
   cursor: pointer;
   font: inherit;
-  padding: 0.85rem 1rem;
-  margin-top: 0.75rem;
+  padding: 0.8rem 1rem;
+  margin-top: 0.55rem;
+}
+
+.count-on-us-widget--cart-summary .count-on-us-widget__toggle {
+  margin-top: 0.7rem;
+  justify-content: center;
+  text-align: center;
 }
 
 .count-on-us-widget__toggle:focus-visible {
@@ -79,6 +92,12 @@
   gap: 0.55rem;
 }
 
+.count-on-us-widget__section + .count-on-us-widget__section {
+  margin-top: 0.35rem;
+  padding-top: 0.9rem;
+  border-top: 1px solid rgba(17, 24, 39, 0.08);
+}
+
 .count-on-us-widget__section-title {
   margin: 0;
   font-size: 0.92rem;
@@ -113,6 +132,162 @@
   justify-content: space-between;
   gap: 0.75rem;
   align-items: baseline;
+}
+
+.count-on-us-widget__cause-link {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.45rem;
+  min-width: 0;
+  color: inherit;
+  text-decoration: none;
+}
+
+.count-on-us-widget__cause-link:hover,
+.count-on-us-widget__cause-link:focus-visible {
+  text-decoration: underline;
+  text-decoration-color: rgba(146, 64, 14, 0.5);
+}
+
+.count-on-us-widget__cause-link-text {
+  color: #6b7280;
+  font-size: 0.82rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.count-on-us-widget__cart-annotation {
+  margin: 0.3rem 0 0;
+  color: #6b7280;
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.count-on-us-widget__cart-annotation-tooltip {
+  gap: 0.3rem;
+}
+
+.count-on-us-widget__cart-annotation-tooltip .count-on-us-widget__tooltip-bubble {
+  left: 0;
+  transform: none;
+  width: min(16rem, calc(100vw - 2rem));
+}
+
+.count-on-us-widget__cart-annotation-tooltip .count-on-us-widget__tooltip-bubble::after {
+  left: 1rem;
+  transform: none;
+}
+
+.count-on-us-widget__cart-annotation-trigger {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  color: #6b7280;
+  font: inherit;
+  font-weight: 500;
+  cursor: help;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 0.14em;
+}
+
+.count-on-us-widget__cart-annotation-trigger:focus-visible {
+  outline: 2px solid #92400e;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.count-on-us-widget__row span {
+  min-width: 0;
+}
+
+.count-on-us-widget__label-with-info {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.count-on-us-widget__tooltip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.count-on-us-widget__tooltip-trigger {
+  width: 1.1rem;
+  height: 1.1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid rgba(146, 64, 14, 0.28);
+  background: rgba(146, 64, 14, 0.08);
+  color: #92400e;
+  font-size: 0.72rem;
+  line-height: 1;
+  font-weight: 700;
+  padding: 0;
+  cursor: help;
+}
+
+.count-on-us-widget__tooltip:focus-within .count-on-us-widget__tooltip-trigger {
+  outline: 2px solid #92400e;
+  outline-offset: 2px;
+}
+
+.count-on-us-widget__tooltip-bubble {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 0.45rem);
+  transform: translateX(-50%);
+  width: min(16rem, 70vw);
+  padding: 0.6rem 0.7rem;
+  border-radius: 10px;
+  background: #111827;
+  color: #f9fafb;
+  font-size: 0.78rem;
+  line-height: 1.35;
+  white-space: pre-line;
+  box-shadow: 0 12px 24px rgba(17, 24, 39, 0.24);
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+  transition:
+    opacity 120ms ease,
+    visibility 120ms ease;
+  z-index: 2;
+}
+
+.count-on-us-widget__tooltip-bubble::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 0.35rem;
+  border-style: solid;
+  border-color: #111827 transparent transparent transparent;
+}
+
+.count-on-us-widget__tooltip:hover .count-on-us-widget__tooltip-bubble,
+.count-on-us-widget__tooltip:focus-within .count-on-us-widget__tooltip-bubble {
+  opacity: 1;
+  visibility: visible;
+}
+
+.count-on-us-widget__row--total {
+  padding-top: 0.35rem;
+  margin-top: 0.15rem;
+  border-top: 1px solid rgba(17, 24, 39, 0.08);
+  font-weight: 600;
+}
+
+.count-on-us-widget__estimate-tag {
+  color: #6b7280;
+  font-style: normal;
+  font-size: 0.85em;
 }
 
 .count-on-us-widget__subdued {
@@ -164,14 +339,14 @@
 .count-on-us-widget__modal {
   width: min(32rem, 100%);
   max-height: min(80vh, 42rem);
-  overflow: auto;
   border-radius: 20px;
   background: #fffdf9;
   color: #1f2937;
-  padding: 1rem;
+  padding: 1rem 0.75rem 1rem 1rem;
   box-shadow: 0 24px 60px rgba(17, 24, 39, 0.28);
   display: grid;
   gap: 1rem;
+  overflow: hidden;
 }
 
 .count-on-us-widget__modal-header {
@@ -179,6 +354,15 @@
   justify-content: space-between;
   gap: 1rem;
   align-items: start;
+  padding-right: 0.25rem;
+}
+
+.count-on-us-widget__modal-body {
+  max-height: calc(min(80vh, 42rem) - 5.5rem);
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-right: 0.45rem;
+  scrollbar-gutter: stable;
 }
 
 .count-on-us-widget__modal-close {
@@ -188,4 +372,38 @@
   font: inherit;
   cursor: pointer;
   padding: 0.25rem;
+}
+
+.count-on-us-widget__details {
+  border: 1px solid rgba(146, 64, 14, 0.12);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.68);
+  padding: 0.15rem 0.85rem 0.85rem;
+}
+
+.count-on-us-widget__details-summary {
+  cursor: pointer;
+  font-weight: 600;
+  list-style: none;
+  padding: 0.7rem 0 0.55rem;
+}
+
+.count-on-us-widget__details-summary::-webkit-details-marker {
+  display: none;
+}
+
+.count-on-us-widget__details-summary::before {
+  content: "+";
+  display: inline-block;
+  margin-right: 0.55rem;
+  color: #92400e;
+}
+
+.count-on-us-widget__details[open] .count-on-us-widget__details-summary::before {
+  content: "-";
+}
+
+.count-on-us-widget__details-body {
+  display: grid;
+  gap: 0.65rem;
 }

--- a/extensions/count-on-us-product-widget/assets/donation-widget.css
+++ b/extensions/count-on-us-product-widget/assets/donation-widget.css
@@ -56,6 +56,10 @@
   gap: 1rem;
 }
 
+.count-on-us-widget__panel[hidden] {
+  display: none !important;
+}
+
 .count-on-us-widget__status {
   margin: 0;
   padding: 0.85rem 1rem;

--- a/extensions/count-on-us-product-widget/assets/product-donation-widget.js
+++ b/extensions/count-on-us-product-widget/assets/product-donation-widget.js
@@ -27,6 +27,45 @@
       return "";
     }
   };
+  const slugify = (value) =>
+    String(value ?? "")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+  const RECONCILIATION_EXPLANATIONS = {
+    estimatedTotal:
+      "This is the current estimated total for this item before Count On Us subtracts the costs and reserves that need to be covered first.",
+    labor:
+      "This portion helps cover the time required to make, prepare, or fulfill this item before any donation amount is estimated.",
+    materials:
+      "This portion helps cover the raw materials used to make this item before any donation amount is estimated.",
+    equipment:
+      "This portion helps cover equipment usage and wear involved in producing this item before any donation amount is estimated.",
+    packaging:
+      "This estimate helps cover packaging and shipping materials, which need to be paid before the remaining amount can be donated.",
+    pod: "This portion helps cover any print-on-demand production cost tied to this item before any donation amount is estimated.",
+    mistakeBuffer:
+      "This portion sets aside a small buffer for remakes, spoilage, or similar production issues so those costs do not come out of the donation estimate later.",
+    fees:
+      "This estimate helps cover payment processing fees charged on the order. The exact amount can vary depending on how the purchase is completed.",
+    taxReserve:
+      "This estimate sets aside money for taxes that may be owed on the sale, so that amount is not counted as part of the donation estimate.",
+    estimatedDonationPool:
+      "This is the amount left after estimated costs, fees, and reserves are subtracted from the total. That remainder is then split between the causes and any portion the shop keeps.",
+    allocatedDonations:
+      "This is the portion of the remaining amount that is currently assigned to the causes connected to this item.",
+    retainedByShop:
+      "This is any remaining portion that stays with the shop instead of being assigned to a cause. When this item is set to donate 100%, this should be zero.",
+    remainder:
+      "This shows any small leftover difference between the total and the displayed estimate buckets. It should usually be zero.",
+  };
+  const renderInfoLabel = (label, explanationKey) => {
+    const explanation = RECONCILIATION_EXPLANATIONS[explanationKey];
+    if (!explanation) return escapeHtml(label);
+
+    const tooltipId = `count-on-us-tooltip-${slugify(explanationKey)}-${slugify(label)}`;
+    return `<span class="count-on-us-widget__label-with-info"><span>${escapeHtml(label)}</span><span class="count-on-us-widget__tooltip"><button type="button" class="count-on-us-widget__tooltip-trigger" aria-describedby="${tooltipId}" aria-label="Learn more about ${escapeHtml(label)}">?</button><span class="count-on-us-widget__tooltip-bubble" id="${tooltipId}" role="tooltip">${escapeHtml(explanation)}</span></span></span>`;
+  };
   const toVariantGid = (value) => {
     const normalized = String(value ?? "").trim();
     if (!normalized) return "";
@@ -36,6 +75,25 @@
   };
   const findVariant = (payload, variantId) => payload.variants.find((variant) => variant.variantId === variantId) || payload.variants[0] || null;
   const closestAddToCartForm = (container) => container.closest("form[action*='/cart/add']") || document.querySelector("form[action*='/cart/add']");
+  const setContainerVisibility = (container, visible) => {
+    if (container.dataset.countOnUsDesignMode === "true") {
+      container.hidden = false;
+      container.removeAttribute("hidden");
+      container.style.removeProperty("display");
+      return;
+    }
+
+    if (visible) {
+      container.hidden = false;
+      container.removeAttribute("hidden");
+      container.style.removeProperty("display");
+      return;
+    }
+
+    container.hidden = true;
+    container.setAttribute("hidden", "");
+    container.style.display = "none";
+  };
   const getVariantId = (container) => {
     const variantInput = closestAddToCartForm(container)?.querySelector("[name='id']");
     if (variantInput) return toVariantGid(variantInput.value);
@@ -50,6 +108,26 @@
   };
   const scaleVariant = (variant, quantity) => {
     const nextQuantity = Math.max(1, quantity);
+    const estimatedTotal = money(variant.reconciliation?.estimatedTotal || variant.price) * nextQuantity;
+    const labor = money(variant.reconciliation?.labor || variant.laborCost) * nextQuantity;
+    const materials = money(variant.reconciliation?.materials) * nextQuantity;
+    const equipment = money(variant.reconciliation?.equipment) * nextQuantity;
+    const packaging = money(variant.reconciliation?.packaging);
+    const pod = money(variant.reconciliation?.pod || variant.podCostTotal) * nextQuantity;
+    const mistakeBuffer = money(variant.reconciliation?.mistakeBuffer || variant.mistakeBufferAmount) * nextQuantity;
+    const processingRate = money(variant.shopifyFees?.processingRate) / 100;
+    const managedMarketsRate = variant.shopifyFees?.managedMarketsApplicable ? money(variant.shopifyFees?.managedMarketsRate) / 100 : 0;
+    const processingFlatFee = money(variant.shopifyFees?.processingFlatFee);
+    const shopifyFees = estimatedTotal * (processingRate + managedMarketsRate) + processingFlatFee;
+    const taxReserve = money(variant.taxReserve?.estimatedAmount) * nextQuantity;
+    const allocatedDonations = variant.causes.reduce(
+      (sum, cause) => sum + money(cause.estimatedDonationAmount) * nextQuantity,
+      0,
+    );
+    const retainedByShop = Math.max(
+      0,
+      estimatedTotal - (allocatedDonations + labor + materials + equipment + packaging + pod + mistakeBuffer + shopifyFees + taxReserve),
+    );
     const scaleLine = (line) => ({ ...line, lineCost: (money(line.lineCost) * nextQuantity).toFixed(2) });
     return {
       ...variant,
@@ -62,6 +140,20 @@
       mistakeBufferAmount: (money(variant.mistakeBufferAmount) * nextQuantity).toFixed(2),
       causes: variant.causes.map((cause) => ({ ...cause, estimatedDonationAmount: (money(cause.estimatedDonationAmount) * nextQuantity).toFixed(2) })),
       taxReserve: { ...variant.taxReserve, estimatedAmount: (money(variant.taxReserve.estimatedAmount) * nextQuantity).toFixed(2) },
+      reconciliation: {
+        estimatedTotal: estimatedTotal.toFixed(2),
+        allocatedDonations: allocatedDonations.toFixed(2),
+        retainedByShop: retainedByShop.toFixed(2),
+        labor: labor.toFixed(2),
+        materials: materials.toFixed(2),
+        equipment: equipment.toFixed(2),
+        packaging: packaging.toFixed(2),
+        pod: pod.toFixed(2),
+        mistakeBuffer: mistakeBuffer.toFixed(2),
+        shopifyFees: shopifyFees.toFixed(2),
+        taxReserve: taxReserve.toFixed(2),
+        remainder: "0.00",
+      },
     };
   };
   const fetchJson = async (url) => {
@@ -79,8 +171,20 @@
     const json = await fetchJson(`${proxyBase}/products/${encodeURIComponent(container.dataset.productId)}`);
     return json.data;
   };
-  const row = (label, value) => `<tr><td>${escapeHtml(label)}</td><td>${escapeHtml(value)}</td></tr>`;
   const section = (title, body) => `<section class="count-on-us-widget__section"><h4 class="count-on-us-widget__section-title">${escapeHtml(title)}</h4>${body}</section>`;
+  const buildReconciliationRows = (reconciliation) =>
+    [
+      { label: "Labor", key: "labor", value: money(reconciliation.labor), estimated: false },
+      { label: "Materials", key: "materials", value: money(reconciliation.materials), estimated: false },
+      { label: "Equipment", key: "equipment", value: money(reconciliation.equipment), estimated: false },
+      { label: "Packaging", key: "packaging", value: money(reconciliation.packaging), estimated: true },
+      { label: "POD", key: "pod", value: money(reconciliation.pod), estimated: false },
+      { label: "Mistake buffer", key: "mistakeBuffer", value: money(reconciliation.mistakeBuffer), estimated: false },
+      { label: "Shopify fees", key: "fees", value: money(reconciliation.shopifyFees), estimated: true },
+      { label: "Tax reserve", key: "taxReserve", value: money(reconciliation.taxReserve), estimated: true },
+    ]
+      .filter((row) => Math.abs(row.value) >= 0.01)
+      .sort((left, right) => right.value - left.value || left.label.localeCompare(right.label));
   const renderVariant = (panel, payload, variantId, quantity) => {
     const variant = findVariant(payload, variantId);
     if (!variant) {
@@ -94,30 +198,27 @@
           `<div class="count-on-us-widget__list">${scaled.causes
             .map((cause) => {
               const donationLink = safeExternalUrl(cause.donationLink);
-              return `<article class="count-on-us-widget__cause"><div class="count-on-us-widget__cause-line"><strong>${escapeHtml(cause.name)}</strong><strong>${formatMoney(money(cause.estimatedDonationAmount), cause.donationCurrencyCode)}</strong></div><div class="count-on-us-widget__cause-line"><span class="count-on-us-widget__subdued">${escapeHtml(cause.donationPercentage)}% of the estimated donation pool</span>${donationLink ? `<a href="${donationLink}" target="_blank" rel="noreferrer" class="count-on-us-widget__subdued">Donate direct</a>` : ""}</div></article>`;
+              return `<article class="count-on-us-widget__cause"><div class="count-on-us-widget__cause-line">${donationLink ? `<a href="${donationLink}" target="_blank" rel="noreferrer" class="count-on-us-widget__cause-link"><strong>${escapeHtml(cause.name)}</strong><span class="count-on-us-widget__cause-link-text">Learn more</span></a>` : `<strong>${escapeHtml(cause.name)}</strong>`}<strong>${formatMoney(money(cause.estimatedDonationAmount), cause.donationCurrencyCode)}</strong></div><div class="count-on-us-widget__cause-line"><span class="count-on-us-widget__subdued">Estimated for this product</span></div></article>`;
             })
             .join("")}</div>`,
         )
       : "";
-    const costRows = [
-      row("Labor", formatMoney(money(scaled.laborCost), scaled.currencyCode)),
-      ...scaled.materialLines.map((line) => row(line.name, formatMoney(money(line.lineCost), scaled.currencyCode))),
-      ...scaled.equipmentLines.map((line) => row(line.name, formatMoney(money(line.lineCost), scaled.currencyCode))),
-      ...scaled.shippingMaterialLines.map((line) => row(`${line.name} (per shipment)`, formatMoney(money(line.lineCost), scaled.currencyCode))),
-      row("POD", formatMoney(money(scaled.podCostTotal), scaled.currencyCode)),
-      row("Mistake buffer", formatMoney(money(scaled.mistakeBufferAmount), scaled.currencyCode)),
-    ].join("");
-    const fees = section(
-      "Shopify fees",
-      `<div class="count-on-us-widget__list"><div class="count-on-us-widget__row"><span>Payment processing</span><strong>${escapeHtml(scaled.shopifyFees.processingRate)}% + ${formatMoney(money(scaled.shopifyFees.processingFlatFee), scaled.currencyCode)}</strong></div>${scaled.shopifyFees.managedMarketsApplicable ? `<div class="count-on-us-widget__row"><span>Managed Markets</span><strong>${escapeHtml(scaled.shopifyFees.managedMarketsRate)}%</strong></div>` : ""}</div>`,
+    const reconciliationRows = buildReconciliationRows(scaled.reconciliation);
+    const remainderRow =
+      Math.abs(money(scaled.reconciliation.remainder)) >= 0.01
+        ? `<div class="count-on-us-widget__row"><span>${renderInfoLabel("Unattributed remainder", "remainder")}</span><strong>${formatMoney(money(scaled.reconciliation.remainder), scaled.currencyCode)}</strong></div>`
+        : "";
+    const waterfallRows = reconciliationRows
+      .map(
+        (row) =>
+          `<div class="count-on-us-widget__row"><span>Less: ${renderInfoLabel(row.label, row.key)}${row.estimated ? ' <em class="count-on-us-widget__estimate-tag">(estimate)</em>' : ""}</span><strong>- ${formatMoney(row.value, scaled.currencyCode)}</strong></div>`,
+      )
+      .join("");
+    const breakdown = section(
+      "Estimated reconciliation",
+      `<details class="count-on-us-widget__details" data-count-on-us-product-breakdown><summary class="count-on-us-widget__details-summary">See how this estimate is calculated</summary><div class="count-on-us-widget__details-body"><div class="count-on-us-widget__list"><div class="count-on-us-widget__row"><span>${renderInfoLabel("Estimated total", "estimatedTotal")}</span><strong>${formatMoney(money(scaled.reconciliation.estimatedTotal), scaled.currencyCode)}</strong></div>${waterfallRows}<div class="count-on-us-widget__row count-on-us-widget__row--total"><span>${renderInfoLabel("Equals: amount remaining after costs", "estimatedDonationPool")}</span><strong>${formatMoney(money(scaled.reconciliation.allocatedDonations) + money(scaled.reconciliation.retainedByShop), scaled.currencyCode)}</strong></div><div class="count-on-us-widget__row"><span>${renderInfoLabel("Allocated to causes", "allocatedDonations")}</span><strong>${formatMoney(money(scaled.reconciliation.allocatedDonations), scaled.currencyCode)}</strong></div><div class="count-on-us-widget__row"><span>${renderInfoLabel("Retained by shop", "retainedByShop")}</span><strong>${formatMoney(money(scaled.reconciliation.retainedByShop), scaled.currencyCode)}</strong></div>${remainderRow}</div></div></details>`,
     );
-    const taxReserve = scaled.taxReserve.suppressed
-      ? section("Estimated tax reserve", '<p class="count-on-us-widget__status">Estimated tax reserve is currently suppressed.</p>')
-      : section(
-          "Estimated tax reserve",
-          `<div class="count-on-us-widget__list"><div class="count-on-us-widget__row"><span>Rate</span><strong>${escapeHtml(scaled.taxReserve.estimatedRate)}%</strong></div><div class="count-on-us-widget__row"><span>Estimated amount</span><strong>${formatMoney(money(scaled.taxReserve.estimatedAmount), scaled.currencyCode)}</strong></div></div>`,
-        );
-    panel.innerHTML = `${causes}${section("Cost breakdown", `<table class="count-on-us-widget__table"><tbody>${costRows}</tbody></table>`)}${fees}${taxReserve}`;
+    panel.innerHTML = `${causes}${breakdown}`;
   };
   async function setupWidget(container) {
     if (!container || container.dataset.widgetReady === "true") return;
@@ -165,14 +266,15 @@
     try {
       const metadata = await loadMetadata(container);
       if (!metadata.visible) {
-        container.hidden = true;
+        setContainerVisibility(container, false);
         container.dataset.widgetInteractive = "true";
         return;
       }
+      setContainerVisibility(container, true);
       if (metadata.deliveryMode === "preload") payload = await loadPayload(container);
     } catch (error) {
       console.error("[Count On Us Widget] Failed to load metadata:", error);
-      container.hidden = true;
+      setContainerVisibility(container, false);
       container.dataset.widgetInteractive = "true";
       return;
     }

--- a/extensions/count-on-us-product-widget/assets/product-donation-widget.js
+++ b/extensions/count-on-us-product-widget/assets/product-donation-widget.js
@@ -27,12 +27,20 @@
       return "";
     }
   };
+  const toVariantGid = (value) => {
+    const normalized = String(value ?? "").trim();
+    if (!normalized) return "";
+    return normalized.startsWith("gid://shopify/ProductVariant/")
+      ? normalized
+      : `gid://shopify/ProductVariant/${normalized}`;
+  };
   const findVariant = (payload, variantId) => payload.variants.find((variant) => variant.variantId === variantId) || payload.variants[0] || null;
   const closestAddToCartForm = (container) => container.closest("form[action*='/cart/add']") || document.querySelector("form[action*='/cart/add']");
   const getVariantId = (container) => {
-    if (container.dataset.selectedVariantId) return container.dataset.selectedVariantId;
     const variantInput = closestAddToCartForm(container)?.querySelector("[name='id']");
-    return variantInput ? variantInput.value : "";
+    if (variantInput) return toVariantGid(variantInput.value);
+    if (container.dataset.selectedVariantId) return toVariantGid(container.dataset.selectedVariantId);
+    return "";
   };
   const getQuantity = (container) => {
     const quantityInput = closestAddToCartForm(container)?.querySelector("[name='quantity']");
@@ -114,31 +122,58 @@
   async function setupWidget(container) {
     if (!container || container.dataset.widgetReady === "true") return;
     container.dataset.widgetReady = "true";
+    container.dataset.widgetInteractive = "false";
     const toggle = container.querySelector("[data-count-on-us-toggle]");
     const panel = container.querySelector("[data-count-on-us-panel]");
     const liveRegion = container.querySelector("[data-count-on-us-live]");
     if (!toggle || !panel) return;
     let payload = null;
     let isOpen = false;
+    let lastRenderedVariantId = "";
+    let lastRenderedQuantity = 0;
+    let syncTimer = null;
     const setStatus = (message, tone) => {
       panel.innerHTML = `<p class="count-on-us-widget__status${tone === "error" ? " count-on-us-widget__status--error" : ""}">${escapeHtml(message)}</p>`;
       if (liveRegion) liveRegion.textContent = message;
     };
     const renderCurrent = () => {
       if (!payload) return;
-      renderVariant(panel, payload, getVariantId(container), getQuantity(container));
+      const variantId = getVariantId(container);
+      const quantity = getQuantity(container);
+      lastRenderedVariantId = variantId;
+      lastRenderedQuantity = quantity;
+      renderVariant(panel, payload, variantId, quantity);
       if (liveRegion) liveRegion.textContent = "Donation estimate updated.";
+    };
+    const syncCurrent = () => {
+      if (!isOpen || !payload) return;
+      const variantId = getVariantId(container);
+      const quantity = getQuantity(container);
+      if (variantId !== lastRenderedVariantId || quantity !== lastRenderedQuantity) {
+        renderCurrent();
+      }
+    };
+    const startSync = () => {
+      if (syncTimer) return;
+      syncTimer = window.setInterval(syncCurrent, 200);
+    };
+    const stopSync = () => {
+      if (!syncTimer) return;
+      window.clearInterval(syncTimer);
+      syncTimer = null;
     };
     try {
       const metadata = await loadMetadata(container);
       if (!metadata.visible) {
         container.hidden = true;
+        container.dataset.widgetInteractive = "true";
         return;
       }
       if (metadata.deliveryMode === "preload") payload = await loadPayload(container);
     } catch (error) {
       console.error("[Count On Us Widget] Failed to load metadata:", error);
       container.hidden = true;
+      container.dataset.widgetInteractive = "true";
       return;
     }
     toggle.addEventListener("click", async () => {
@@ -146,7 +181,10 @@
       toggle.setAttribute("aria-expanded", String(isOpen));
       panel.hidden = !isOpen;
       toggle.querySelector("[aria-hidden='true']").textContent = isOpen ? "-" : "+";
-      if (!isOpen) return;
+      if (!isOpen) {
+        stopSync();
+        return;
+      }
       if (!payload) {
         setStatus("Loading donation estimate...", "info");
         try {
@@ -158,15 +196,17 @@
         }
       }
       renderCurrent();
+      startSync();
     });
+    container.dataset.widgetBound = "true";
     const form = closestAddToCartForm(container);
-    if (!form) return;
-    form.addEventListener("change", () => {
-      if (isOpen && payload) renderCurrent();
-    });
-    form.addEventListener("input", () => {
-      if (isOpen && payload) renderCurrent();
-    });
+    const eventTarget = form || document;
+    const scheduleSync = () => window.setTimeout(syncCurrent, 0);
+    eventTarget.addEventListener("change", scheduleSync);
+    eventTarget.addEventListener("input", scheduleSync);
+    eventTarget.addEventListener("click", scheduleSync);
+    document.addEventListener("variant:change", scheduleSync);
+    container.dataset.widgetInteractive = "true";
   }
   const boot = (root) => root.querySelectorAll(SELECTOR).forEach((container) => void setupWidget(container));
   if (document.readyState === "loading") {

--- a/extensions/count-on-us-product-widget/blocks/cart-donation-summary.liquid
+++ b/extensions/count-on-us-product-widget/blocks/cart-donation-summary.liquid
@@ -1,7 +1,9 @@
 <div
-  class="count-on-us-widget"
+  class="count-on-us-widget count-on-us-widget--cart-summary"
   data-count-on-us-cart-summary
+  data-count-on-us-design-mode="{{ request.design_mode | json }}"
   data-proxy-base="/apps/count-on-us"
+  {% unless request.design_mode %}hidden{% endunless %}
 >
   <div class="count-on-us-widget__header">
     <h3 class="count-on-us-widget__heading">{{ block.settings.heading | escape }}</h3>
@@ -16,7 +18,6 @@
     aria-expanded="false"
   >
     <span>{{ block.settings.button_label | escape }}</span>
-    <span aria-hidden="true">+</span>
   </button>
 
   <script type="application/json" data-count-on-us-cart-lines>
@@ -25,7 +26,8 @@
         {
           "productId": "gid://shopify/Product/{{ item.product.id }}",
           "variantId": "gid://shopify/ProductVariant/{{ item.variant.id }}",
-          "quantity": {{ item.quantity }}
+          "quantity": {{ item.quantity }},
+          "lineSubtotal": {{ item.final_line_price | divided_by: 100.0 | json }}
         }{% unless forloop.last %},{% endunless %}
       {% endfor %}
     ]
@@ -46,19 +48,19 @@
       "type": "text",
       "id": "heading",
       "label": "Heading",
-      "default": "See your donation impact"
+      "default": "Your purchase is making a difference!"
     },
     {
       "type": "textarea",
       "id": "description",
       "label": "Description",
-      "default": "Open a cart-level view of the estimated donation totals across the causes in your cart."
+      "default": "Open a cart-level view of the causes your purchase supports and how the estimate is calculated."
     },
     {
       "type": "text",
       "id": "button_label",
       "label": "Button label",
-      "default": "See your donation impact"
+      "default": "See donation details"
     }
   ]
 }

--- a/extensions/count-on-us-product-widget/blocks/donation-widget.liquid
+++ b/extensions/count-on-us-product-widget/blocks/donation-widget.liquid
@@ -1,8 +1,8 @@
 <div
   class="count-on-us-widget"
   data-count-on-us-widget
-  data-product-id="{{ product.admin_graphql_api_id }}"
-  data-selected-variant-id="{{ product.selected_or_first_available_variant.admin_graphql_api_id }}"
+  data-product-id="gid://shopify/Product/{{ product.id }}"
+  data-selected-variant-id="gid://shopify/ProductVariant/{{ product.selected_or_first_available_variant.id }}"
   data-selected-quantity="1"
   data-proxy-base="/apps/count-on-us"
 >

--- a/extensions/count-on-us-product-widget/blocks/donation-widget.liquid
+++ b/extensions/count-on-us-product-widget/blocks/donation-widget.liquid
@@ -1,10 +1,12 @@
 <div
   class="count-on-us-widget"
   data-count-on-us-widget
+  data-count-on-us-design-mode="{{ request.design_mode | json }}"
   data-product-id="gid://shopify/Product/{{ product.id }}"
   data-selected-variant-id="gid://shopify/ProductVariant/{{ product.selected_or_first_available_variant.id }}"
   data-selected-quantity="1"
   data-proxy-base="/apps/count-on-us"
+  {% unless request.design_mode %}hidden{% endunless %}
 >
   <div class="count-on-us-widget__header">
     <h3 class="count-on-us-widget__heading">{{ block.settings.heading | escape }}</h3>

--- a/prisma/migrations/20260409183000_provider_connections_foundation/migration.sql
+++ b/prisma/migrations/20260409183000_provider_connections_foundation/migration.sql
@@ -1,0 +1,62 @@
+CREATE TABLE "ProviderConnection" (
+    "id" TEXT NOT NULL,
+    "shopId" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "authType" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'configured',
+    "displayName" TEXT,
+    "credentialsEncrypted" TEXT,
+    "credentialHint" TEXT,
+    "lastSyncedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProviderConnection_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "ProviderVariantMapping" (
+    "id" TEXT NOT NULL,
+    "shopId" TEXT NOT NULL,
+    "connectionId" TEXT NOT NULL,
+    "variantId" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "providerVariantId" TEXT,
+    "providerSku" TEXT,
+    "matchMethod" TEXT,
+    "lastCostSyncedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProviderVariantMapping_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "ProviderCostCache" (
+    "id" TEXT NOT NULL,
+    "mappingId" TEXT NOT NULL,
+    "costLineType" TEXT NOT NULL,
+    "description" TEXT,
+    "amount" DECIMAL(10,2) NOT NULL,
+    "currency" TEXT NOT NULL DEFAULT 'USD',
+    "syncedAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProviderCostCache_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ProviderConnection_shopId_provider_key" ON "ProviderConnection"("shopId", "provider");
+CREATE INDEX "ProviderConnection_shopId_status_idx" ON "ProviderConnection"("shopId", "status");
+
+CREATE UNIQUE INDEX "ProviderVariantMapping_connectionId_variantId_key" ON "ProviderVariantMapping"("connectionId", "variantId");
+CREATE INDEX "ProviderVariantMapping_shopId_provider_idx" ON "ProviderVariantMapping"("shopId", "provider");
+CREATE INDEX "ProviderVariantMapping_variantId_idx" ON "ProviderVariantMapping"("variantId");
+
+CREATE INDEX "ProviderCostCache_mappingId_syncedAt_idx" ON "ProviderCostCache"("mappingId", "syncedAt");
+
+ALTER TABLE "ProviderVariantMapping" ADD CONSTRAINT "ProviderVariantMapping_connectionId_fkey"
+FOREIGN KEY ("connectionId") REFERENCES "ProviderConnection"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "ProviderVariantMapping" ADD CONSTRAINT "ProviderVariantMapping_variantId_fkey"
+FOREIGN KEY ("variantId") REFERENCES "Variant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "ProviderCostCache" ADD CONSTRAINT "ProviderCostCache_mappingId_fkey"
+FOREIGN KEY ("mappingId") REFERENCES "ProviderVariantMapping"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -211,7 +211,8 @@ model Variant {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  costConfig VariantCostConfig?
+  costConfig        VariantCostConfig?
+  providerMappings  ProviderVariantMapping[]
 
   @@unique([shopId, shopifyId])
   @@index([shopId])
@@ -270,6 +271,61 @@ model VariantEquipmentLine {
 
   @@unique([configId, templateLineId])
   @@index([shopId])
+}
+
+model ProviderConnection {
+  id                   String   @id @default(cuid())
+  shopId               String
+  provider             String
+  authType             String
+  status               String   @default("configured")
+  displayName          String?
+  credentialsEncrypted String?
+  credentialHint       String?
+  lastSyncedAt         DateTime?
+  createdAt            DateTime @default(now())
+  updatedAt            DateTime @updatedAt
+
+  mappings ProviderVariantMapping[]
+
+  @@unique([shopId, provider])
+  @@index([shopId, status])
+}
+
+model ProviderVariantMapping {
+  id                String             @id @default(cuid())
+  shopId            String
+  connectionId      String
+  connection        ProviderConnection @relation(fields: [connectionId], references: [id], onDelete: Cascade)
+  variantId         String
+  variant           Variant            @relation(fields: [variantId], references: [id], onDelete: Cascade)
+  provider          String
+  providerVariantId String?
+  providerSku       String?
+  matchMethod       String?
+  lastCostSyncedAt  DateTime?
+  createdAt         DateTime           @default(now())
+  updatedAt         DateTime           @updatedAt
+
+  costLines ProviderCostCache[]
+
+  @@unique([connectionId, variantId])
+  @@index([shopId, provider])
+  @@index([variantId])
+}
+
+model ProviderCostCache {
+  id           String                 @id @default(cuid())
+  mappingId    String
+  mapping      ProviderVariantMapping @relation(fields: [mappingId], references: [id], onDelete: Cascade)
+  costLineType String
+  description  String?
+  amount       Decimal                @db.Decimal(10, 2)
+  currency     String                 @default("USD")
+  syncedAt     DateTime
+  createdAt    DateTime               @default(now())
+
+  @@index([mappingId, syncedAt])
 }
 
 // Phase 3 tables

--- a/tests/ui/cart-donation-summary-workflow.spec.ts
+++ b/tests/ui/cart-donation-summary-workflow.spec.ts
@@ -32,5 +32,5 @@ test("cart donation summary handles carts without donation products", async ({ p
 
   const dialog = page.getByRole("dialog", { name: "Cart donation impact" });
   await expect(dialog).toBeVisible();
-  await expect(dialog.getByText("No donation products in this cart yet.")).toBeVisible();
+  await expect(dialog).toContainText("No donation products in this cart yet.");
 });

--- a/tests/ui/cart-donation-summary-workflow.spec.ts
+++ b/tests/ui/cart-donation-summary-workflow.spec.ts
@@ -3,6 +3,9 @@ import { expect, test } from "@playwright/test";
 
 test("cart donation summary modal renders per-cause totals and returns focus on close", async ({ page }) => {
   await page.goto("/ui-fixtures/cart-donation-summary");
+  await page.waitForFunction(
+    () => (window as Window & { __COUNT_ON_US_CART_SUMMARY_READY__?: boolean }).__COUNT_ON_US_CART_SUMMARY_READY__ === true,
+  );
 
   const trigger = page.getByRole("button", { name: "See your donation impact" });
   await trigger.click();
@@ -21,6 +24,9 @@ test("cart donation summary modal renders per-cause totals and returns focus on 
 
 test("cart donation summary handles carts without donation products", async ({ page }) => {
   await page.goto("/ui-fixtures/cart-donation-summary?mode=no-donation");
+  await page.waitForFunction(
+    () => (window as Window & { __COUNT_ON_US_CART_SUMMARY_READY__?: boolean }).__COUNT_ON_US_CART_SUMMARY_READY__ === true,
+  );
 
   await page.getByRole("button", { name: "See your donation impact" }).click();
 

--- a/tests/ui/cart-donation-summary-workflow.spec.ts
+++ b/tests/ui/cart-donation-summary-workflow.spec.ts
@@ -7,15 +7,50 @@ test("cart donation summary modal renders per-cause totals and returns focus on 
     () => (window as Window & { __COUNT_ON_US_CART_SUMMARY_READY__?: boolean }).__COUNT_ON_US_CART_SUMMARY_READY__ === true,
   );
 
-  const trigger = page.getByRole("button", { name: "See your donation impact" });
+  const trigger = page.getByRole("button", { name: "See donation details" });
   await trigger.click();
+
+  await expect(page.locator(".cart-item").nth(0)).toContainText("Donations apply");
+  await expect(page.locator(".cart-item").nth(1)).toContainText("Donations apply");
+  await page.locator(".cart-item").nth(1).getByLabel("Show supported causes").focus();
+  await expect(page.locator(".cart-item").nth(1).getByRole("tooltip")).toContainText("50% to Community Library");
 
   const dialog = page.getByRole("dialog", { name: "Cart donation impact" });
   await expect(dialog).toBeVisible();
-  await expect(dialog.getByText("Neighborhood Arts")).toBeVisible();
-  await expect(dialog.getByText("Community Library")).toBeVisible();
-  await expect(dialog.getByText("$13.00")).toBeVisible();
-  await expect(dialog.getByText("$3.00")).toBeVisible();
+  await expect(dialog.locator(".count-on-us-widget__cause").nth(0)).toContainText("Neighborhood Arts");
+  await expect(dialog.locator(".count-on-us-widget__cause").nth(0)).toContainText("$23.88");
+  await expect(dialog.locator(".count-on-us-widget__cause").nth(1)).toContainText("Community Library");
+  await expect(dialog.locator(".count-on-us-widget__cause").nth(1)).toContainText("$3.16");
+  const disclosure = dialog.locator("[data-count-on-us-cart-breakdown]");
+  await expect(disclosure).toContainText("See how this estimate is calculated");
+  await disclosure.locator("summary").click();
+  await expect(disclosure).toContainText("Estimated reconciliation");
+  await expect(disclosure).toContainText("Estimated total");
+  await expect(disclosure).toContainText("$55.00");
+  await expect(disclosure).toContainText("Less: Tax reserve");
+  await expect(disclosure).toContainText("- $9.01");
+  await expect(disclosure).toContainText("Less: Labor");
+  await expect(disclosure).toContainText("- $8.00");
+  await expect(disclosure).toContainText("Less: Materials");
+  await expect(disclosure).toContainText("- $5.00");
+  await expect(disclosure).toContainText("Less: Equipment");
+  await expect(disclosure).toContainText("- $2.75");
+  await expect(disclosure).toContainText("Less: Shopify fees");
+  await expect(disclosure).toContainText("(estimate)");
+  await expect(disclosure).toContainText("- $2.20");
+  await expect(disclosure).toContainText("Less: Packaging");
+  await expect(disclosure).toContainText("- $1.00");
+  await expect(disclosure).toContainText("Equals: amount remaining after costs");
+  await expect(disclosure).toContainText("$27.04");
+  await expect(disclosure).toContainText("Allocated to causes");
+  await expect(disclosure).toContainText("$27.04");
+  await expect(disclosure).toContainText("Retained by shop");
+  await expect(disclosure).toContainText("$0.00");
+  const feesInfo = disclosure.locator('[aria-label="Learn more about Shopify fees"]');
+  await feesInfo.focus();
+  await expect(disclosure.getByRole("tooltip")).toContainText(
+    "This estimate helps cover payment processing fees charged on the order.",
+  );
 
   await page.keyboard.press("Escape");
   await expect(dialog).toHaveCount(0);
@@ -28,9 +63,103 @@ test("cart donation summary handles carts without donation products", async ({ p
     () => (window as Window & { __COUNT_ON_US_CART_SUMMARY_READY__?: boolean }).__COUNT_ON_US_CART_SUMMARY_READY__ === true,
   );
 
-  await page.getByRole("button", { name: "See your donation impact" }).click();
+  await expect(page.locator("[data-count-on-us-cart-summary]")).toHaveCount(0);
+});
+
+test("cart donation summary includes non-cause variants in reconciliation while keeping causes scoped", async ({
+  page,
+}) => {
+  await page.goto("/ui-fixtures/cart-donation-summary?mode=mixed-no-cause");
+  await page.waitForFunction(
+    () => (window as Window & { __COUNT_ON_US_CART_SUMMARY_READY__?: boolean }).__COUNT_ON_US_CART_SUMMARY_READY__ === true,
+  );
+
+  await page.getByRole("button", { name: "See donation details" }).click();
 
   const dialog = page.getByRole("dialog", { name: "Cart donation impact" });
   await expect(dialog).toBeVisible();
-  await expect(dialog).toContainText("No donation products in this cart yet.");
+  await expect(dialog.locator(".count-on-us-widget__cause")).toHaveCount(2);
+  await expect(dialog).not.toContainText("gid://shopify/Product/3");
+  await expect(page.locator(".cart-item").nth(0)).toContainText("Donations apply");
+  await expect(page.locator(".cart-item").nth(1)).toContainText("Donations apply");
+  await expect(page.locator(".cart-item").nth(2).locator("[data-count-on-us-cart-annotation]")).toHaveCount(0);
+
+  const disclosure = dialog.locator("[data-count-on-us-cart-breakdown]");
+  await disclosure.locator("summary").click();
+  await expect(disclosure).toContainText("Estimated total");
+  await expect(disclosure).toContainText("$85.00");
+  await expect(disclosure).toContainText("Allocated to causes");
+  await expect(disclosure).toContainText("$27.04");
+  await expect(disclosure).toContainText("Retained by shop");
+  await expect(disclosure).toContainText("$14.03");
+});
+
+test("cart donation summary stays visible when cart quantities change", async ({ page }) => {
+  await page.goto("/ui-fixtures/cart-donation-summary");
+  await page.waitForFunction(
+    () => (window as Window & { __COUNT_ON_US_CART_SUMMARY_READY__?: boolean }).__COUNT_ON_US_CART_SUMMARY_READY__ === true,
+  );
+
+  const widget = page.locator("[data-count-on-us-cart-summary]");
+  await expect(widget).toBeVisible();
+
+  await page.evaluate(() => {
+    const win = window as unknown as {
+      __COUNT_ON_US_FIXTURE__: { lines: Array<{ quantity: number; lineSubtotal?: number }> };
+      __COUNT_ON_US_FIXTURE_UNIT_PRICES__: Record<number, number>;
+    };
+    win.__COUNT_ON_US_FIXTURE__.lines[0].quantity = 3;
+    win.__COUNT_ON_US_FIXTURE__.lines[0].lineSubtotal = 60;
+
+    const cartItem = document.querySelectorAll(".cart-item")[0];
+    cartItem?.querySelector('[data-fixture-qty]')?.replaceChildren(document.createTextNode("Qty 3"));
+    const quantityInput = cartItem?.querySelector('input[name="updates[]"]');
+    if (quantityInput instanceof HTMLInputElement) {
+      quantityInput.value = "3";
+    }
+  });
+  await expect(page.locator('.cart-item').nth(0)).toContainText("Qty 3");
+  await expect(widget).toBeVisible();
+});
+
+test("cart donation summary refreshes when a new cart line is added", async ({ page }) => {
+  await page.goto("/ui-fixtures/cart-donation-summary");
+  await page.waitForFunction(
+    () => (window as Window & { __COUNT_ON_US_CART_SUMMARY_READY__?: boolean }).__COUNT_ON_US_CART_SUMMARY_READY__ === true,
+  );
+
+  await page.evaluate(() => {
+    const win = window as unknown as {
+      __COUNT_ON_US_FIXTURE__: {
+        lines: Array<{ productId: string; variantId: string; quantity: number; lineSubtotal?: number }>;
+      };
+      __COUNT_ON_US_FIXTURE_UNIT_PRICES__: Record<number, number>;
+    };
+    const nextLine = {
+      productId: "gid://shopify/Product/1",
+      variantId: "gid://shopify/ProductVariant/1",
+      quantity: 1,
+      lineSubtotal: 20,
+    };
+
+    win.__COUNT_ON_US_FIXTURE__.lines.push(nextLine);
+    win.__COUNT_ON_US_FIXTURE_UNIT_PRICES__[win.__COUNT_ON_US_FIXTURE__.lines.length - 1] = 20;
+
+    const article = document.createElement("article");
+    article.className = "cart-item";
+    article.style.display = "grid";
+    article.style.gap = "0.35rem";
+    article.style.padding = "0.85rem 1rem";
+    article.style.borderRadius = "14px";
+    article.style.background = "#ffffff";
+    article.style.border = "1px solid rgba(17, 24, 39, 0.08)";
+    article.innerHTML =
+      '<div style="display:flex;justify-content:space-between;gap:1rem;align-items:baseline;"><a href="/products/fixture-3" style="color:#111827;font-weight:600;text-decoration:none;">Fixture cart item 3</a><span data-fixture-qty style="color:#6b7280;font-size:0.92rem;">Qty 1</span></div><label style="display:grid;gap:0.25rem;max-width:6rem;"><span style="color:#6b7280;font-size:0.82rem;">Quantity</span><input name="updates[]" type="number" value="1" min="0"></label>';
+    document.querySelector("main section")?.appendChild(article);
+  });
+
+  await expect(page.locator("[data-count-on-us-cart-summary]")).toBeVisible();
+  await expect(page.locator(".cart-item")).toHaveCount(3);
+  await page.locator(".cart-item").nth(2).locator('input[name="updates[]"]').dispatchEvent("change");
+  await expect(page.locator(".cart-item").nth(2)).toContainText("Donations apply");
 });

--- a/tests/ui/product-donation-widget-fixture.spec.ts
+++ b/tests/ui/product-donation-widget-fixture.spec.ts
@@ -1,0 +1,15 @@
+/* eslint-disable testing-library/prefer-screen-queries */
+import { expect, test } from "@playwright/test";
+
+test("product donation widget fixture renders the widget shell and product controls", async ({ page }) => {
+  await page.goto("/ui-fixtures/product-donation-widget");
+  await page.waitForFunction(
+    () =>
+      (window as Window & { __COUNT_ON_US_PRODUCT_WIDGET_READY__?: boolean }).__COUNT_ON_US_PRODUCT_WIDGET_READY__ === true,
+  );
+
+  await expect(page.locator("[data-count-on-us-widget]")).toBeVisible();
+  await expect(page.getByRole("button", { name: "See how we calculate this" })).toBeVisible();
+  await expect(page.locator('select[name="id"]')).toBeVisible();
+  await expect(page.locator('input[name="quantity"]')).toBeVisible();
+});

--- a/tests/ui/product-donation-widget-fixture.spec.ts
+++ b/tests/ui/product-donation-widget-fixture.spec.ts
@@ -9,7 +9,8 @@ test("product donation widget fixture renders the widget shell and product contr
   );
 
   await expect(page.locator("[data-count-on-us-widget]")).toBeVisible();
-  await expect(page.getByRole("button", { name: "See how we calculate this" })).toBeVisible();
+  const trigger = page.getByRole("button", { name: "See how we calculate this" });
+  await expect(trigger).toBeVisible();
   await expect(page.locator('select[name="id"]')).toBeVisible();
   await expect(page.locator('input[name="quantity"]')).toBeVisible();
 });

--- a/tests/ui/products-workflow.spec.ts
+++ b/tests/ui/products-workflow.spec.ts
@@ -1,0 +1,21 @@
+/* eslint-disable testing-library/prefer-screen-queries */
+import { expect, test } from "@playwright/test";
+
+test("products page can queue a catalog sync without clearing seed data", async ({ page, request }) => {
+  const bootstrapResponse = await request.get("/ui-fixtures/products-bootstrap");
+  expect(bootstrapResponse.ok()).toBeTruthy();
+
+  const bootstrap = await bootstrapResponse.json();
+  await page.goto(bootstrap.productsUrl);
+
+  await expect(page.getByRole("heading", { name: "Catalog sync" })).toBeVisible();
+  await expect(page.getByText("Last completed sync")).toBeVisible();
+
+  await page.getByRole("button", { name: "Sync catalog now" }).click();
+
+  await expect(
+    page.getByText(
+      "Catalog sync queued. Shopify products and variants will be added or refreshed without deleting your existing local seed data.",
+    ),
+  ).toBeVisible();
+});

--- a/tests/ui/provider-connections-workflow.spec.ts
+++ b/tests/ui/provider-connections-workflow.spec.ts
@@ -1,0 +1,43 @@
+/* eslint-disable testing-library/prefer-screen-queries */
+import { expect, test } from "@playwright/test";
+
+test("provider connections can save and disconnect Printify credentials", async ({ page, request }) => {
+  const bootstrapResponse = await request.get("/ui-fixtures/provider-connections-bootstrap");
+  expect(bootstrapResponse.ok()).toBeTruthy();
+
+  const bootstrap = await bootstrapResponse.json();
+  await page.goto(bootstrap.providerConnectionsUrl);
+
+  await expect(page.getByRole("heading", { name: "Provider Connections" })).toBeVisible();
+  await expect(page.getByText("Variants with SKU")).toBeVisible();
+  await expect(page.getByText("Printify API keys can be stored now.")).toBeVisible();
+
+  await page.getByLabel("Shop label").fill("Fixture Printify Shop");
+  await page.getByLabel("API key").fill("pk_live_fixture_printify_key_1234");
+  await page.getByRole("button", { name: "Save Printify credentials" }).click();
+
+  await expect(
+    page.getByText("Printify credentials saved. Live validation and sync will land in a follow-up provider tranche.").last(),
+  ).toBeVisible();
+  await expect(page.getByText("Stored credential hint: ****1234.")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Disconnect Printify" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Disconnect Printify" }).click();
+
+  await expect(page.getByText("Printify disconnected.").last()).toBeVisible();
+  await expect(page.getByRole("button", { name: "Save Printify credentials" })).toBeVisible();
+});
+
+test("provider connections show a visible validation error when Printify API key is blank", async ({ page, request }) => {
+  const bootstrapResponse = await request.get("/ui-fixtures/provider-connections-bootstrap");
+  expect(bootstrapResponse.ok()).toBeTruthy();
+
+  const bootstrap = await bootstrapResponse.json();
+  await page.goto(bootstrap.providerConnectionsUrl);
+
+  await page.getByLabel("Shop label").fill("Fixture Printify Shop");
+  await page.getByRole("button", { name: "Save Printify credentials" }).click();
+
+  await expect(page.getByText("Printify API key is required.").last()).toBeVisible();
+  await expect(page.getByRole("button", { name: "Save Printify credentials" })).toBeVisible();
+});

--- a/tests/unit/routes/api.widget.products.$productId.test.ts
+++ b/tests/unit/routes/api.widget.products.$productId.test.ts
@@ -12,9 +12,7 @@ const { checkRateLimit } = vi.hoisted(() => ({
   checkRateLimit: vi.fn(),
 }));
 const prisma = {
-  shop: {
-    findUnique: vi.fn(),
-  },
+  $queryRaw: vi.fn(),
 };
 
 vi.mock("../../../app/utils/public-auth.server", () => ({
@@ -41,16 +39,14 @@ describe("api.widget.products.$productId loader", () => {
     buildWidgetProductMetadata.mockReset();
     buildWidgetProductPayload.mockReset();
     checkRateLimit.mockReset();
-    prisma.shop.findUnique.mockReset();
+    prisma.$queryRaw.mockReset();
   });
 
   it("returns widget payloads for authenticated shops", async () => {
     authenticatePublicAppProxyRequest.mockResolvedValue({
       shopifyDomain: "fixture-shop.myshopify.com",
     });
-    prisma.shop.findUnique.mockResolvedValue({
-      shopId: "shop-1",
-    });
+    prisma.$queryRaw.mockResolvedValue([{ shopId: "shop-1" }]);
     checkRateLimit.mockReturnValue({
       allowed: true,
       headers: new Headers({
@@ -94,9 +90,7 @@ describe("api.widget.products.$productId loader", () => {
     authenticatePublicAppProxyRequest.mockResolvedValue({
       shopifyDomain: "fixture-shop.myshopify.com",
     });
-    prisma.shop.findUnique.mockResolvedValue({
-      shopId: "shop-1",
-    });
+    prisma.$queryRaw.mockResolvedValue([{ shopId: "shop-1" }]);
     checkRateLimit.mockReturnValue({
       allowed: false,
       headers: new Headers({
@@ -126,9 +120,7 @@ describe("api.widget.products.$productId loader", () => {
     authenticatePublicAppProxyRequest.mockResolvedValue({
       shopifyDomain: "fixture-shop.myshopify.com",
     });
-    prisma.shop.findUnique.mockResolvedValue({
-      shopId: "shop-1",
-    });
+    prisma.$queryRaw.mockResolvedValue([{ shopId: "shop-1" }]);
     checkRateLimit.mockReturnValue({
       allowed: true,
       headers: new Headers(),
@@ -155,9 +147,7 @@ describe("api.widget.products.$productId loader", () => {
     authenticatePublicAppProxyRequest.mockResolvedValue({
       shopifyDomain: "fixture-shop.myshopify.com",
     });
-    prisma.shop.findUnique.mockResolvedValue({
-      shopId: "shop-1",
-    });
+    prisma.$queryRaw.mockResolvedValue([{ shopId: "shop-1" }]);
     checkRateLimit.mockReturnValue({
       allowed: true,
       headers: new Headers(),

--- a/tests/unit/routes/app.products._index.test.ts
+++ b/tests/unit/routes/app.products._index.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authenticateAdminRequest = vi.fn();
+const isPlaywrightBypassRequest = vi.fn();
+const jobQueueSend = vi.fn();
+
+const prisma = {
+  shop: {
+    findUnique: vi.fn(),
+  },
+  auditLog: {
+    findFirst: vi.fn(),
+    create: vi.fn(),
+  },
+  product: {
+    findMany: vi.fn(),
+  },
+};
+
+vi.mock("../../../app/utils/admin-auth.server", () => ({
+  authenticateAdminRequest,
+  isPlaywrightBypassRequest,
+}));
+
+vi.mock("../../../app/db.server", () => ({
+  prisma,
+}));
+
+vi.mock("../../../app/jobs/queue.server", () => ({
+  jobQueue: {
+    send: jobQueueSend,
+  },
+}));
+
+describe("app.products._index action", () => {
+  beforeEach(() => {
+    authenticateAdminRequest.mockReset();
+    isPlaywrightBypassRequest.mockReset();
+    jobQueueSend.mockReset();
+    prisma.auditLog.create.mockReset();
+  });
+
+  it("queues a full catalog sync for the current shop", async () => {
+    authenticateAdminRequest.mockResolvedValue({
+      session: { shop: "fixture-shop.myshopify.com" },
+    });
+    isPlaywrightBypassRequest.mockReturnValue(false);
+    prisma.auditLog.create.mockResolvedValue(undefined);
+    jobQueueSend.mockResolvedValue("job-1");
+
+    const { action } = await import("../../../app/routes/app.products._index");
+    const response = await action({
+      request: new Request("http://localhost/app/products", {
+        method: "POST",
+        body: new URLSearchParams({ intent: "sync-catalog" }),
+      }),
+      params: {},
+      context: {},
+    } as never);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ok: true,
+      message:
+        "Catalog sync queued. Shopify products and variants will be added or refreshed without deleting your existing local seed data.",
+    });
+    expect(prisma.auditLog.create).toHaveBeenCalledOnce();
+    expect(jobQueueSend).toHaveBeenCalledWith(
+      "catalog.sync",
+      { shopId: "fixture-shop.myshopify.com" },
+      { singletonKey: "fixture-shop.myshopify.com", singletonSeconds: 900 },
+    );
+  });
+
+  it("skips queueing during Playwright bypass requests", async () => {
+    authenticateAdminRequest.mockResolvedValue({
+      session: { shop: "fixture-shop.myshopify.com" },
+    });
+    isPlaywrightBypassRequest.mockReturnValue(true);
+    prisma.auditLog.create.mockResolvedValue(undefined);
+
+    const { action } = await import("../../../app/routes/app.products._index");
+    const response = await action({
+      request: new Request("http://localhost/app/products?__playwrightShop=fixture-shop.myshopify.com", {
+        method: "POST",
+        body: new URLSearchParams({ intent: "sync-catalog" }),
+      }),
+      params: {},
+      context: {},
+    } as never);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ok: true,
+      message:
+        "Catalog sync queued. Shopify products and variants will be added or refreshed without deleting your existing local seed data.",
+    });
+    expect(prisma.auditLog.create).toHaveBeenCalledOnce();
+    expect(jobQueueSend).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add provider connection schema, encrypted credential storage, and a real Provider Connections admin page with Printify save/disconnect flows
- add a manual catalog sync action so Shopify products and variants can be refreshed without replacing local seed data
- harden the storefront donation widgets across product and cart flows, including app-proxy routing fixes, live cart refresh behavior, line-level annotations, clearer reconciliation math, and Theme Editor preview visibility
- expand fixtures and UI coverage around provider setup and storefront donation widget behavior

## Testing
- npx prisma generate
- npx tsc --noEmit
- npm run lint
- npm test
- npm run test:ui
